### PR TITLE
Exit with a message when SELinux is disabled

### DIFF
--- a/lagofy.sh
+++ b/lagofy.sh
@@ -170,7 +170,7 @@ ost_init() {
     mkdir "$PREFIX"
     mkdir "$PREFIX/logs"
     mkdir "$PREFIX/images"
-    chcon -t svirt_image_t "$PREFIX/images"
+    chcon -t svirt_image_t "$PREFIX/images" && { echo "SELinux is disabled on the machine"; getenforce; return 1;}
 
     # generate 8 char UUID common to all resources
     # VMs with name <uuid>-ost-<suite>-<vmname>


### PR DESCRIPTION
chcon is used without checking if SELinux is not disabled.
This cause a message of the form :
"chcon: can't apply partial context to unlabeled file ..."

This patch adds a check for SELinux enforcing status and exists
with a proper message if SELinux is disabled.

Signed-of-by: Eli Mesika <emesika@redhat.com>