### PR TITLE
ansible: [TEST] check updating only the iso domain nfs version

### DIFF
--- a/ansible-suite-master/test-scenarios/test_002_ansible.py
+++ b/ansible-suite-master/test-scenarios/test_002_ansible.py
@@ -75,7 +75,6 @@ def test_ansible_run(
                 "nfs": {
                     "address": engine_fqdn,
                     "path": "/exports/nfs/share1",
-                    "version": "v4_2",
                 },
             },
             "second-nfs": {
@@ -83,7 +82,6 @@ def test_ansible_run(
                 "nfs": {
                     "address": engine_fqdn,
                     "path": "/exports/nfs/share2",
-                    "version": "v4_2",
                 },
             },
             "templates": {
@@ -91,7 +89,6 @@ def test_ansible_run(
                 "nfs": {
                     "address": engine_fqdn,
                     "path": "/exports/nfs/exported",
-                    "version": "v4_2",
                 },
             },
             "iso": {


### PR DESCRIPTION
This patch tries only updating the nfs version of the iso domain, instead of all domains.
On test_002_bootstrap, we set the nfs version of the iso domain to V3:
  sd_type='iso',
  nfs_version='v3',

This patch selectively check the nfs version of the iso domain, as done in 
https://gerrit.ovirt.org/c/ovirt-system-tests/+/118435/1/ansible-suite-master/test-scenarios/test_002_ansible.py