### PR TITLE
ovirtlib: ansiblelib - fix mutable default value

### DIFF
--- a/network-suite-master/ovirtlib/ansiblelib.py
+++ b/network-suite-master/ovirtlib/ansiblelib.py
@@ -14,11 +14,11 @@ class AnsibleExecutionFailure(Exception):
 
 
 class Playbook(object):
-    def __init__(self, playbook, extra_vars={}):
+    def __init__(self, playbook, extra_vars=None):
         self._execution_stats = None
         self._idempotency_check_stats = None
         self._playbook = playbook
-        self._extra_vars = extra_vars
+        self._extra_vars = extra_vars if extra_vars else {}
         self._extra_vars['ansible_python_interpreter'] = 'python3'
 
     @property


### PR DESCRIPTION
With a mutable default value a function doesn't behave idempotently on
consecutive invocations.

Signed-off-by: Eitan Raviv <eraviv@redhat.com>
Change-Id: I372bbc14459ae07cda200366a50dcc11dd9e4c7f