### PR TITLE
002_bootstrap: move engine backup before image tests

### DIFF
--- a/basic-suite-master/test-scenarios/test_002_bootstrap.py
+++ b/basic-suite-master/test-scenarios/test_002_bootstrap.py
@@ -147,6 +147,7 @@ _TEST_LIST = [
     "test_add_event",
     "test_verify_add_all_hosts",
     "test_generate_openscap_report",
+    "test_verify_engine_backup",
     "test_upload_cirros_image",
     "test_create_cirros_template",
     "test_complete_hosts_setup",
@@ -160,7 +161,6 @@ _TEST_LIST = [
     "test_add_non_vm_network",
     "test_add_vm_network",
     "test_verify_uploaded_image_and_template",
-    "test_verify_engine_backup",
     "test_add_nonadmin_user",
     "test_add_vm_permissions_to_user",
 ]


### PR DESCRIPTION
We're still having problems with 'test_upload_cirros_image'
and 'test_create_cirros_template' tests - they fail randomly.
The suggested workaround for now is to wait more before trying
to work with images, so we're moving engine backup test (which
takes ~3 mins to execute) to happen before the problematic tests.

Signed-off-by: Marcin Sobczyk <msobczyk@redhat.com>
