### PR TITLE
revert imageio hack

### DIFF
--- a/common/deploy-scripts/setup_first_he_host.sh
+++ b/common/deploy-scripts/setup_first_he_host.sh
@@ -114,10 +114,6 @@ copy_dependencies() {
         src: /root/ssg-rhel8-ds.xml
         dest: /root
   when: profile_stat.stat.exists and profile_stat.stat.size > 0
-- name: Copy imageio-client to HE VM
-  copy:
-    src: /usr/lib64/python3.6/site-packages/ovirt_imageio/client
-    dest: /usr/lib64/python3.6/site-packages/ovirt_imageio/
 EOF
 
 }


### PR DESCRIPTION
This should no longer be needed:

commit 26ee8457e0fe9140d75a5d8e5bc12208c020be68
Author: Michal Skrivanek <michal.skrivanek@redhat.com>
Date:   Fri Oct 15 16:29:25 2021 +0200

    he: copy imageio-client files to engine.

    this is supposed to be a short-term hack to allow ansible to upload
    cirros image to HE. On regular engine we inculde
ovirt-imageio-client
    rpm but it's a bit cumbersome to push that to HE VM. We want to
change
    this entirely to use imageio from pypi so this should be sufficient
for
    now...

    Change-Id: I35e12e4b3d0c83c04224144dafb736b449d9c4a7
    Signed-off-by: Michal Skrivanek <michal.skrivanek@redhat.com>
