### PR TITLE
Revert "basic: Remove time sync"

### DIFF
--- a/basic-suite-master/test-scenarios/test_002_bootstrap.py
+++ b/basic-suite-master/test-scenarios/test_002_bootstrap.py
@@ -101,6 +101,7 @@ _TEST_LIST = [
     "test_add_dc",
     "test_add_cluster",
     "test_add_hosts",
+    "test_sync_time",
     "test_get_version",
     "test_get_domains",
     "test_get_operating_systems",
@@ -316,6 +317,12 @@ def test_add_cluster(engine_api, ost_cluster_name, ost_dc_name):
                 ],
             ),
         )
+
+
+@order_by(_TEST_LIST)
+def test_sync_time(ansible_hosts, engine_hostname):
+    ansible_hosts.shell('chronyc add server {}'.format(engine_hostname))
+    ansible_hosts.shell('chronyc makestep')
 
 
 @order_by(_TEST_LIST)

--- a/common/deploy-scripts/setup_engine.sh
+++ b/common/deploy-scripts/setup_engine.sh
@@ -9,7 +9,10 @@ systemctl start crond
 rm -rf /dev/shm/yum /dev/shm/*.rpm
 fstrim -va
 
+systemctl enable chronyd
+systemctl start chronyd
 firewall-cmd --permanent --zone=public --add-interface=eth0
+firewall-cmd --permanent --zone=public --add-service=ntp
 firewall-cmd --reload
 
 # rotate logs quicker, because of the debug logs they tend to flood the root partition if they run > 15 minutes

--- a/common/deploy-scripts/setup_storage.sh
+++ b/common/deploy-scripts/setup_storage.sh
@@ -121,6 +121,7 @@ configure_firewalld() {
     firewall-cmd --permanent --add-service=iscsi-target
     firewall-cmd --permanent --add-service=ldap
     firewall-cmd --permanent --add-service=nfs
+    firewall-cmd --permanent --add-service=ntp
     firewall-cmd --reload
 }
 


### PR DESCRIPTION
This reverts commit 8a0261005bff8a3f001dd5ac716f362f679e3b53.

breaks openscap DISA STIG test "Ensure Chrony is only configured with
the server directive"
