### PR TITLE
basic: Temporarily disable openscap reports

### DIFF
--- a/basic-suite-master/test-scenarios/test_002_bootstrap.py
+++ b/basic-suite-master/test-scenarios/test_002_bootstrap.py
@@ -1715,6 +1715,7 @@ def test_verify_uploaded_image_and_template(
 
 
 @order_by(_TEST_LIST)
+@pytest.mark.xfail(reason="openscap is currently broken", strict=True)
 def test_generate_openscap_report(
     ansible_by_hostname,
     hosts_hostnames,


### PR DESCRIPTION
basic: Temporarily disable openscap reports

We have two problems that make openscap reports fail currently:
- session locking with tmux
- chrony configuration

Let's xfail the test until we resolve them.
