### PR TITLE
lagofy: clean up with sudo when custom-ost-images have root permissions

### DIFF
--- a/lagofy.sh
+++ b/lagofy.sh
@@ -60,7 +60,7 @@ ost_destroy() {
         ) 9>/tmp/ost.lock
     fi
     [[ -s "$PREFIX/sshd_pid" ]] && { echo "killing IPv6 sshd proxy"; kill $(cat "$PREFIX/sshd_pid"); }
-    [[ -d "$OST_REPO_ROOT/custom-ost-images" ]] && { echo "remove custom ost images"; rm -rf "$OST_REPO_ROOT/custom-ost-images"; }
+    [[ -d "$OST_REPO_ROOT/custom-ost-images" ]] && { echo "remove custom ost images"; rm -rf "$OST_REPO_ROOT/custom-ost-images" 2>/dev/null || sudo rm -rf "$OST_REPO_ROOT/custom-ost-images"; }
     _deployment_exists && rm -rf "$PREFIX" && echo "removed $PREFIX"
     unset OST_INITIALIZED $(env | grep ^OST_IMAGES_ | cut -d= -f1)
 }


### PR DESCRIPTION
This can happen if the helper ost-images.sh gets aborted in the middle
of deploying custom images when it runs under root. We need to clean
up as root as well, but let's do that only when necessary, i.e. when we
cannot remove as current user.
