### PR TITLE
he: Delay the custom repo check

### DIFF
--- a/he-basic-suite-master/test-scenarios/test_001_he_deploy.py
+++ b/he-basic-suite-master/test-scenarios/test_001_he_deploy.py
@@ -6,6 +6,10 @@
 
 import os
 
+import pytest
+
+from ost_utils.deployment_utils import package_mgmt
+
 
 def test_run_dig_loop(
     suite_dir,
@@ -98,3 +102,10 @@ def test_install_sar_collection(root_dir, ansible_engine):
 
 def test_add_engine_to_artifacts(artifacts, he_host_name, artifact_list):
     artifacts[he_host_name] = artifact_list
+
+
+def test_check_installed_packages(request, ansible_all):
+    if request.config.getoption('--skip-custom-repos-check'):
+        pytest.skip('the check was disabled by the run argument')
+
+    package_mgmt.check_installed_packages(ansible_all)

--- a/ost_utils/pytest/fixtures/deployment.py
+++ b/ost_utils/pytest/fixtures/deployment.py
@@ -96,6 +96,7 @@ def deploy(
     ansible_vms_to_deploy,
     ansible_hosts,
     deploy_scripts,
+    deploy_hosted_engine,
     root_dir,
     working_dir,
     request,
@@ -141,7 +142,7 @@ def deploy(
             'dnf upgrade --nogpgcheck -y --disableplugin versionlock -x ovirt-release-master,ovirt-release-master-tested,ovirt-engine-appliance,rhvm-appliance,ovirt-node-ng-image-update,redhat-virtualization-host-image-update'
         )
         # check if packages from custom repos were used
-        if not request.config.getoption('--skip-custom-repos-check'):
+        if not request.config.getoption('--skip-custom-repos-check') and not deploy_hosted_engine:
             package_mgmt.check_installed_packages(ansible_vms_to_deploy)
 
     # report package versions


### PR DESCRIPTION
Engine is deployed later than other guests, so we delay the cusom repos
check until it's up.