### PR TITLE
setup_host.sh: delete setup for sasl2/qemu.conf

### DIFF
--- a/common/deploy-scripts/setup_host.sh
+++ b/common/deploy-scripts/setup_host.sh
@@ -62,10 +62,6 @@ fi
 # FIPS setup for encrypted VNC
 # FIXME this just duplicates what ovirt-vnc-sasl.yml does
 if [[ $(cat /proc/sys/crypto/fips_enabled) == 1 ]]; then
-    cat > /etc/sasl2/qemu.conf << EOF
-mech_list: scram-sha-1
-sasldb_path: /etc/sasl2/vnc_passwd.db
-EOF
     echo dummy_password | saslpasswd2 -a dummy_db -f /etc/sasl2/vnc_passwd.db dummy_user -p
     chown qemu:qemu /etc/sasl2/vnc_passwd.db
     sed -i "s/^#vnc_sasl =.*/vnc_sasl = 1/" /etc/libvirt/qemu.conf


### PR DESCRIPTION
the setup for /etc/sasl2/qemu.conf already as part of the host
deploy[1].
therefore we can remove it from setup_host.sh

[1] https://github.com/oVirt/ovirt-engine/blob/master/packaging/ansible-runner-service-project/project/roles/ovirt-host-setup-vnc-sasl/tasks/main.yml#L8