### PR TITLE
Update ost-of-ost.yaml

### DIFF
--- a/.github/workflows/ost-of-ost.yaml
+++ b/.github/workflows/ost-of-ost.yaml
@@ -1,6 +1,7 @@
 name: OST of OST
 
 on:
+  push:
   issue_comment:
     types: [created]
 


### PR DESCRIPTION
After pushing more code into an existing PR it is required to trigger OST manually via a comment on the PR. It would be quicker and more efficient if OST is triggered automatically on each push.