### PR TITLE
github: trigger checks on push

### DIFF
--- a/.github/workflows/ost-of-ost.yaml
+++ b/.github/workflows/ost-of-ost.yaml
@@ -1,6 +1,7 @@
 name: OST of OST
 
 on:
+  push:
   issue_comment:
     types: [created]
 


### PR DESCRIPTION
Trigger checks on every push of new code to a PR, instead of only
on PR creation and with manual comment creation. This should be quicker
and more efficient.

Change-Id: I68500b0226a6ccdf98125f7851682fd5038f0951
Signed-off-by: Eitan Raviv <eraviv@redhat.com>