### PR TITLE
network: extend ServerRebootTimeout

### DIFF
--- a/network-suite-master/fixtures/engine.py
+++ b/network-suite-master/fixtures/engine.py
@@ -54,7 +54,7 @@ def ovirt_engine_setup(deploy, engine_facts, engine_answer_file_path):
 
     commands = [
         f'engine-setup --offline --accept-defaults --config-append={ANSWER_FILE_TMP}',
-        'engine-config --set ServerRebootTimeout=150',
+        'engine-config --set ServerRebootTimeout=180',
         'systemctl restart ovirt-engine',
     ]
     for command in commands:


### PR DESCRIPTION
Extend the timeout since sometimes it is not enough causing flakiness in
runs.

Change-Id: Ib20bed9208c54f7c7c8b94f40683f56a7a3a3636
Signed-off-by: Eitan Raviv <eraviv@redhat.com>