### PR TITLE
he, basic: increase VM memory size for UEFI boot

### DIFF
--- a/basic-suite-master/test-scenarios/test_002_bootstrap.py
+++ b/basic-suite-master/test-scenarios/test_002_bootstrap.py
@@ -1231,14 +1231,14 @@ def test_add_blank_vms(engine_api, ost_cluster_name):
     )
 
     vm_params.name = BACKUP_VM_NAME
-    vm_params.memory = 96 * MB
-    vm_params.memory_policy.guaranteed = 64 * MB
+    vm_params.memory = 160 * MB
+    vm_params.memory_policy.guaranteed = 106 * MB
     vms_service.add(vm_params)
     backup_vm_service = test_utils.get_vm_service(engine, BACKUP_VM_NAME)
 
     vm_params.name = VM0_NAME
     least_hotplug_increment = 256 * MB
-    required_memory = 96 * MB
+    required_memory = 160 * MB
     vm_params.memory = required_memory
     vm_params.memory_policy.guaranteed = required_memory
     vm_params.memory_policy.max = required_memory + least_hotplug_increment
@@ -1307,10 +1307,10 @@ def test_add_blank_high_perf_vm2(engine_api, ost_dc_name, ost_cluster_name):
             ),
             memory_policy=sdk4.types.MemoryPolicy(
                 ballooning=False,
-                guaranteed=64 * MB,
+                guaranteed=106 * MB,
                 max=256 * MB,
             ),
-            memory=96 * MB,
+            memory=160 * MB,
             high_availability=sdk4.types.HighAvailability(
                 enabled=True,
                 priority=100,


### PR DESCRIPTION
In Cluster 4.7 we now default to UEFI boot, that needs a bit more
memory.
