### PR TITLE
Remove test for export button

### DIFF
--- a/basic-suite-master/test-scenarios/test_100_basic_ui_sanity.py
+++ b/basic-suite-master/test-scenarios/test_100_basic_ui_sanity.py
@@ -441,21 +441,18 @@ def test_virtual_machines(
     assert vm_list_view.is_new_button_enabled() is True
     assert vm_list_view.is_edit_button_enabled() is False
     assert vm_list_view.is_shutdown_button_enabled() is False
-    assert vm_list_view.is_export_button_enabled() is False
     assert vm_list_view.is_migrate_button_enabled() is False
 
     vm_list_view.select_entity('vm0')
     assert vm_list_view.is_new_button_enabled() is True
     assert vm_list_view.is_edit_button_enabled() is True
     assert vm_list_view.is_shutdown_button_enabled() is True
-    assert vm_list_view.is_export_button_enabled() is False
     assert vm_list_view.is_migrate_button_enabled() is True
 
     vm_list_view.poweroff()
     assert vm_list_view.is_new_button_enabled() is True
     assert vm_list_view.is_edit_button_enabled() is True
     assert vm_list_view.is_shutdown_button_enabled() is False
-    assert vm_list_view.is_export_button_enabled() is True
     assert vm_list_view.is_migrate_button_enabled() is False
 
     save_screenshot('vms-list-success')

--- a/ost_utils/selenium/page_objects/VmListView.py
+++ b/ost_utils/selenium/page_objects/VmListView.py
@@ -36,9 +36,6 @@ class VmListView(EntityListView):
     def is_shutdown_button_enabled(self):
         return self.ovirt_driver.is_button_enabled('Shutdown')
 
-    def is_export_button_enabled(self):
-        return self.ovirt_driver.is_button_enabled('Export')
-
     def is_migrate_button_enabled(self):
         return self.ovirt_driver.is_button_enabled('Migrate')
 


### PR DESCRIPTION
This patch removes tests for the Export button on the vm list view. The reason is that we test only top level action buttons, and the export button has been moved to the kebab menu.