### PR TITLE
github: reduce noise for non-OST comments

### DIFF
--- a/.github/workflows/ost.yaml
+++ b/.github/workflows/ost.yaml
@@ -31,7 +31,8 @@ jobs:
     runs-on: ost-trigger
     timeout-minutes: 4
     if: github.event_name == 'workflow_dispatch' ||
-      ( github.event.issue.pull_request && (
+      ( github.event.issue.pull_request &&
+        startsWith(github.event.comment.body, '/ost') && (
           github.event.comment.author_association == 'MEMBER' ||
           github.event.comment.author_association == 'COLLABORATOR')
       )


### PR DESCRIPTION
no need to run the job when comment doesn't start with /ost. Fails
faster and doesn't need runner's time.
