### PR TITLE
enable baseos&appstream repos on RHEL

### DIFF
--- a/common/deploy-scripts/setup_first_he_host.sh
+++ b/common/deploy-scripts/setup_first_he_host.sh
@@ -66,11 +66,11 @@ dnf_update() {
   copy:
     src: /etc/yum.repos.d
     dest: /etc
-- name: DNF update the system. TODO remove baseos&appstream once appliance is up to date
+- name: DNF update the system. TODO remove baseos&appstream once RHV appliance is regularly up to date.
   dnf:
     name:  "*"
     state: latest
-    enablerepo: "*-baseos,*-appstream"
+    enablerepo: "rhel*-baseos,rhel*-appstream"
     exclude:
       - ovirt-release-master
       - ovirt-release-master-tested


### PR DESCRIPTION
RHV appliance is often very outdated and it's missing packages. No need to enable for oVirt appliance that is being built regularly.