### PR TITLE
setup: Enably deny debug for fapolicyd

### DIFF
--- a/common/deploy-scripts/setup_engine.sh
+++ b/common/deploy-scripts/setup_engine.sh
@@ -34,3 +34,17 @@ cp /usr/share/doc/ovirt-engine/mibs/* /usr/share/snmp/mibs
 systemctl start snmptrapd
 systemctl enable snmptrapd
 
+# Fapolicyd with debug output
+if [ "$(systemctl is-active fapolicyd)" = "active" ]; then
+  mkdir -p /etc/systemd/system/fapolicyd.service.d
+  cat > /etc/systemd/system/fapolicyd.service.d/10-debug-deny.conf << EOF
+[Service]
+Type=simple
+Restart=no
+ExecStart=
+ExecStart=/usr/sbin/fapolicyd --debug-deny
+EOF
+  restorecon -vR /etc/systemd/system/fapolicyd.service.d
+  systemctl daemon-reload
+  systemctl restart fapolicyd
+fi

--- a/common/deploy-scripts/setup_host.sh
+++ b/common/deploy-scripts/setup_host.sh
@@ -72,3 +72,18 @@ EOF
 fi
 
 coredump_kill
+
+# Fapolicyd with debug output
+if [ "$(systemctl is-active fapolicyd)" = "active" ]; then
+  mkdir -p /etc/systemd/system/fapolicyd.service.d
+  cat > /etc/systemd/system/fapolicyd.service.d/10-debug-deny.conf << EOF
+[Service]
+Type=simple
+Restart=no
+ExecStart=
+ExecStart=/usr/sbin/fapolicyd --debug-deny
+EOF
+  restorecon -vR /etc/systemd/system/fapolicyd.service.d
+  systemctl daemon-reload
+  systemctl restart fapolicyd
+fi


### PR DESCRIPTION
Anything that is denied by fapolicyd should be
logged to journal when the unit runs with
--debug-deny. This should help to identify
any "Operation not permitted" that might be related
to fapolicyd.

Signed-off-by: Ales Musil <amusil@redhat.com>