### PR TITLE
use storage vm on ansible suite

### DIFF
--- a/ansible-suite-master/test-scenarios/conftest.py
+++ b/ansible-suite-master/test-scenarios/conftest.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
 #
+import pytest
 
 from ost_utils.pytest.fixtures.ansible import *
 
@@ -23,6 +24,7 @@ from ost_utils.pytest.fixtures.backend import host0_hostname
 from ost_utils.pytest.fixtures.backend import host1_hostname
 from ost_utils.pytest.fixtures.backend import hosts_hostnames
 from ost_utils.pytest.fixtures.backend import management_network_supports_ipv4
+from ost_utils.pytest.fixtures.backend import storage_hostname
 
 from ost_utils.pytest.fixtures.defaults import ansible_vms_to_deploy
 from ost_utils.pytest.fixtures.defaults import hostnames_to_add
@@ -38,3 +40,17 @@ from ost_utils.pytest.fixtures.env import root_dir
 from ost_utils.pytest.fixtures.env import ssh_key_file
 from ost_utils.pytest.fixtures.env import suite_dir
 from ost_utils.pytest.fixtures.env import working_dir
+
+from ost_utils.pytest.fixtures.storage import *
+
+
+@pytest.fixture(scope="session")
+def sd_iscsi_host_ip(storage_ips_for_network, storage_network_name):  # pylint: disable=function-redefined
+    return storage_ips_for_network(storage_network_name)[0]
+
+
+@pytest.fixture(scope="session")
+def sd_iscsi_ansible_host(
+    ansible_storage,  # noqa: F811
+):  # pylint: disable=function-redefined
+    return ansible_storage

--- a/ansible-suite-master/test-scenarios/test_002_ansible.py
+++ b/ansible-suite-master/test-scenarios/test_002_ansible.py
@@ -13,9 +13,11 @@ def test_ansible_run(
     hostnames_to_add,
     engine_ip_url,
     engine_fqdn,
-    engine_storage_ips,
     engine_full_username,
     engine_password,
+    storage_hostname,
+    sd_iscsi_host_ip,
+    sd_iscsi_ansible_host,
 ):
     infra(
         ansible_engine,
@@ -73,7 +75,7 @@ def test_ansible_run(
                 "master": "true",
                 "state": "present",
                 "nfs": {
-                    "address": engine_fqdn,
+                    "address": storage_hostname,
                     "path": "/exports/nfs/share1",
                     "version": "v4_2",
                 },
@@ -81,7 +83,7 @@ def test_ansible_run(
             "second-nfs": {
                 "state": "present",
                 "nfs": {
-                    "address": engine_fqdn,
+                    "address": storage_hostname,
                     "path": "/exports/nfs/share2",
                     "version": "v4_2",
                 },
@@ -89,7 +91,7 @@ def test_ansible_run(
             "templates": {
                 "domain_function": "export",
                 "nfs": {
-                    "address": engine_fqdn,
+                    "address": storage_hostname,
                     "path": "/exports/nfs/exported",
                     "version": "v4_2",
                 },
@@ -97,7 +99,7 @@ def test_ansible_run(
             "iso": {
                 "domain_function": "iso",
                 "nfs": {
-                    "address": engine_fqdn,
+                    "address": storage_hostname,
                     "path": "/exports/nfs/iso",
                     "version": "v4_2",
                 },
@@ -106,10 +108,10 @@ def test_ansible_run(
                 "iscsi": {
                     "target": "iqn.2014-07.org.ovirt:storage",
                     "port": 3260,
-                    "address": engine_storage_ips[0],
+                    "address": sd_iscsi_host_ip,
                     "username": "username",
                     "password": "password",
-                    "lun_id": lun.get_uuids(ansible_engine)[:2],
+                    "lun_id": lun.get_uuids(sd_iscsi_ansible_host)[:2],
                 }
             },
         },


### PR DESCRIPTION
Currently, ansible suite uses an engine for storage, using the storage VM
added in the previous patch.