### PR TITLE
use storage vm on network suite

### DIFF
--- a/network-suite-master/fixtures/ansible.py
+++ b/network-suite-master/fixtures/ansible.py
@@ -31,6 +31,11 @@ def host1_facts(ansible_host1_facts, af):
     return _machine_facts(ansible_host1_facts.get_all(), af)
 
 
+@pytest.fixture(scope="session")
+def storage_facts(ansible_storage_facts, af):
+    return _machine_facts(ansible_storage_facts.get_all(), af)
+
+
 @pytest.fixture(scope="session", autouse=True)
 def ansible_clean_private_dirs():
     try:

--- a/network-suite-master/fixtures/storage.py
+++ b/network-suite-master/fixtures/storage.py
@@ -16,7 +16,7 @@ DEFAULT_DOMAIN_PATH = '/exports/nfs/share1'
 
 
 @pytest.fixture(scope='session')
-def default_storage_domain(system, engine_facts, host_0_up, default_data_center):
+def default_storage_domain(system, storage_facts, host_0_up, default_data_center):
     host_0_up.workaround_bz_1779280()
     storage_domain = storagelib.StorageDomain(system)
     try:
@@ -28,7 +28,7 @@ def default_storage_domain(system, engine_facts, host_0_up, default_data_center)
             host=host_0_up,
             host_storage_data=storagelib.HostStorageData(
                 storage_type=storagelib.StorageType.NFS,
-                address=engine_facts.default_ip(urlize=True),
+                address=storage_facts.default_ip(urlize=True),
                 path=DEFAULT_DOMAIN_PATH,
                 nfs_version=storagelib.NfsVersion.V4_2,
             ),
@@ -40,9 +40,9 @@ def default_storage_domain(system, engine_facts, host_0_up, default_data_center)
 
 
 @pytest.fixture(scope='session')
-def lun_id(engine_facts):
+def lun_id(storage_facts):
     # Reads a lun id value from the file
-    node = sshlib.Node(engine_facts.default_ip(), engine_facts.ssh_password)
+    node = sshlib.Node(storage_facts.default_ip(), storage_facts.ssh_password)
     ret = node.exec_command(' '.join(['cat', '/root/multipath.txt']))
     assert ret.code == 0
     return ret.out.splitlines()[0]

--- a/network-suite-master/test-scenarios/conftest.py
+++ b/network-suite-master/test-scenarios/conftest.py
@@ -7,6 +7,7 @@ from fixtures.ansible import af
 from fixtures.ansible import host0_facts
 from fixtures.ansible import host1_facts
 from fixtures.ansible import engine_facts
+from fixtures.ansible import storage_facts
 from fixtures.ansible import ansible_clean_private_dirs
 
 from fixtures.ansible import ansible_collect_logs
@@ -56,6 +57,7 @@ from ost_utils.pytest.fixtures.ansible import ansible_host0_facts
 from ost_utils.pytest.fixtures.ansible import ansible_host1
 from ost_utils.pytest.fixtures.ansible import ansible_host1_facts
 from ost_utils.pytest.fixtures.ansible import ansible_hosts
+from ost_utils.pytest.fixtures.ansible import ansible_storage_facts
 from ost_utils.pytest.fixtures.ansible import ansible_inventory
 from ost_utils.pytest.fixtures.ansible import ansible_storage
 from ost_utils.pytest.fixtures.artifacts import artifacts
@@ -71,6 +73,7 @@ from ost_utils.pytest.fixtures.backend import deploy_scripts
 from ost_utils.pytest.fixtures.backend import host0_hostname
 from ost_utils.pytest.fixtures.backend import host1_hostname
 from ost_utils.pytest.fixtures.backend import hosts_hostnames
+from ost_utils.pytest.fixtures.backend import storage_hostname
 from ost_utils.pytest.fixtures.backend import management_network_supports_ipv4
 from ost_utils.pytest.fixtures.backend import tested_ip_version
 from ost_utils.pytest.fixtures.defaults import ansible_vms_to_deploy


### PR DESCRIPTION
Currently, network suite uses an engine for storage, using the storage VM
added in the previous patch.