### PR TITLE
basic: fix VDSM hook permissions

### DIFF
--- a/basic-suite-master/test-scenarios/test_002_bootstrap.py
+++ b/basic-suite-master/test-scenarios/test_002_bootstrap.py
@@ -918,7 +918,9 @@ def test_get_host_hook(hosts_service, ost_dc_name, ansible_hosts, root_dir):
     ansible_hosts.copy(
         src=hook_full_path,
         dest='/usr/libexec/vdsm/hooks/after_hostdev_list_by_caps',
-        mode='preserve',
+        owner='root',
+        group='root',
+        mode='0755',
     )
 
     # refresh host capabilities


### PR DESCRIPTION
The test for custom VDSM hook was highly dependent on the machine
configuration and could fail on non-standard setup (e.g. modified
umask). It is best to explicitly define what user and permissions we
expect on the hook file when deploying it.

Signed-off-by: Tomáš Golembiovský <tgolembi@redhat.com>