### PR TITLE
github: Fix custom repo artifact collection

### DIFF
--- a/ost_utils/deployment_utils/package_mgmt.py
+++ b/ost_utils/deployment_utils/package_mgmt.py
@@ -153,7 +153,13 @@ def _github_resolve_commit_to_workflow_run(repo, commit) -> str:
     )
     for run in runs_response.json()["workflow_runs"]:
         if run["head_sha"] == commit:
-            return run["id"]
+            run_id = run["id"]
+            artifacts_response = _github_get(
+                f"https://api.github.com/repos/oVirt/{repo}/actions/runs/{run_id}/artifacts"
+            ).json()
+            for artifact in artifacts_response["artifacts"]:
+                if not artifact["expired"] and artifact["name"].startswith("rpm"):
+                    return run_id
 
     raise RuntimeError(f"No workflow runs found for commit {commit}")
 


### PR DESCRIPTION
Some projects have multiple runs, not all of which include artifacts.
We should therefore check for artifacts during the search for workflow
run corresponding to specific commit.