### PR TITLE
Use nobest in 'DNF update the system'

### DIFF
--- a/common/deploy-scripts/setup_first_he_host.sh
+++ b/common/deploy-scripts/setup_first_he_host.sh
@@ -72,6 +72,7 @@ dnf_update() {
     name:  "*"
     state: latest
     enablerepo: "rhel*-baseos,rhel*-appstream"
+    nobest: yes
     exclude:
       - ovirt-release-master
       - ovirt-release-master-tested

--- a/ost_utils/pytest/fixtures/deployment.py
+++ b/ost_utils/pytest/fixtures/deployment.py
@@ -137,8 +137,9 @@ def deploy(
     if custom_repos is not None:
         repo_urls = package_mgmt.expand_repos(custom_repos, working_dir, ost_images_distro)
         package_mgmt.add_custom_repos(ansible_vms_to_deploy, repo_urls)
+        # TODO remove --nobest when the engine works with ansible-core
         ansible_vms_to_deploy.shell(
-            'dnf upgrade --nogpgcheck -y --disableplugin versionlock -x ovirt-release-master,ovirt-release-master-tested,ovirt-engine-appliance,rhvm-appliance,ovirt-node-ng-image-update,redhat-virtualization-host-image-update'
+            'dnf upgrade --nogpgcheck -y --disableplugin versionlock -x ovirt-release-master,ovirt-release-master-tested,ovirt-engine-appliance,rhvm-appliance,ovirt-node-ng-image-update,redhat-virtualization-host-image-update --nobest'
         )
         # check if packages from custom repos were used
         if not request.config.getoption('--skip-custom-repos-check'):


### PR DESCRIPTION
Without this, it fails, because it wants to update
ovirt-ansible-collection, which now requires
ansible-collection-ansible-utils, which requires ansible-core, whereas
the engine still conflicts with ansible-core.

TODO: Revert this (and perhaps some more) when the engine is fixed to
work with ansible-core.

Change-Id: I4851b76a353edd274cb4cfc76a0467b117f443c4
Signed-off-by: Yedidyah Bar David <didi@redhat.com>