### PR TITLE
Click dependency fixed for black

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -50,6 +50,7 @@ commands =
 [testenv:black]
 deps =
     black==21.12b0
+    click==8.0.2
 commands =
     {envpython} -m black \
         -l 119 \


### PR DESCRIPTION
A recent version of click has been released which removes _unicodefun.
This resulted in inability to run ost.

Error:
  File "/home/asocha/work/code/github.com/arso/ovirt-system-tests/.tox/black/lib/python3.9/site-packages/black/__init__.py", line 137
2, in patched_main
    patch_click()
  File "/home/asocha/work/code/github.com/arso/ovirt-system-tests/.tox/black/lib/python3.9/site-packages/black/__init__.py", line 135
8, in patch_click
    from click import _unicodefun
ImportError: cannot import name '_unicodefun' from 'click' (/home/asocha/work/code/github.com/arso/ovirt-system-tests/.tox/black/lib/
python3.9/site-packages/click/__init__.py)