### PR TITLE
ansible: Change arg order passed to ansible-runner

### DIFF
--- a/ost_utils/ansible/collection.py
+++ b/ost_utils/ansible/collection.py
@@ -35,7 +35,7 @@ def _run_playbook(ansible_engine, playbook_yaml, ansible_inventory=None, ssh_key
         dest=os.path.join(tmp_path, 'project/playbook.yml'),
     )
 
-    ansible_engine.shell(f'ansible-runner -i {run_uuid} -vvv -p playbook.yml run {tmp_path}')
+    ansible_engine.shell(f'ansible-runner -i {run_uuid} -vvv run {tmp_path} -p playbook.yml')
 
     return (tmp_path, run_uuid)
 


### PR DESCRIPTION
New ansible-runner versions require '-p' argument to be passed after the
'run' command.

Signed-off-by: Marcin Sobczyk <msobczyk@redhat.com>
