### PR TITLE
Support for internal Keycloak authentication

### DIFF
--- a/basic-suite-master/test-scenarios/conftest.py
+++ b/basic-suite-master/test-scenarios/conftest.py
@@ -47,6 +47,8 @@ from ost_utils.pytest.fixtures.deployment import set_sar_interval
 
 from ost_utils.pytest.fixtures.engine import *
 
+from ost_utils.pytest.fixtures.keycloak import *
+
 from ost_utils.pytest.fixtures.env import ost_images_distro
 from ost_utils.pytest.fixtures.env import root_dir
 from ost_utils.pytest.fixtures.env import ssh_key_file

--- a/basic-suite-master/test-scenarios/test_002_bootstrap.py
+++ b/basic-suite-master/test-scenarios/test_002_bootstrap.py
@@ -41,6 +41,7 @@ from ost_utils import shell
 from ost_utils import test_utils
 from ost_utils import utils
 from ost_utils import versioning
+from ost_utils import keycloak
 
 LOGGER = logging.getLogger(__name__)
 
@@ -162,6 +163,7 @@ _TEST_LIST = [
     "test_add_vm_network",
     "test_verify_uploaded_image_and_template",
     "test_add_nonadmin_user",
+    "test_add_nonadmin_keycloak_user",
     "test_add_vm_permissions_to_user",
 ]
 
@@ -1113,7 +1115,7 @@ def test_verify_notifier(ansible_engine, ost_dc_name):
 
 
 @order_by(_TEST_LIST)
-def test_verify_engine_backup(ansible_engine, engine_api, ost_dc_name, is_node_suite):
+def test_verify_engine_backup(ansible_engine, engine_api, ost_dc_name, is_node_suite, keycloak_enabled):
     ansible_engine.file(path='/var/log/ost-engine-backup', state='directory', mode='0755')
 
     engine = engine_api.system_service()
@@ -1600,7 +1602,10 @@ def test_add_direct_lun_vm0(engine_api, sd_iscsi_host_direct_luns):
 
 
 @order_by(_TEST_LIST)
-def test_add_nonadmin_user(engine_api, ansible_engine, nonadmin_username, nonadmin_password):
+def test_add_nonadmin_user(engine_api, ansible_engine, nonadmin_username, nonadmin_password, keycloak_enabled):
+    if keycloak_enabled:
+        pytest.skip(' [2022-04-04] Internal Keycloak authentication enabled. Skipping AAA tests')
+
     ansible_engine.shell(f"ovirt-aaa-jdbc-tool user add {nonadmin_username}")
     ansible_engine.shell(
         f"ovirt-aaa-jdbc-tool user password-reset {nonadmin_username} \
@@ -1616,19 +1621,87 @@ def test_add_nonadmin_user(engine_api, ansible_engine, nonadmin_username, nonadm
 
 
 @order_by(_TEST_LIST)
-def test_add_vm_permissions_to_user(engine_api, ansible_engine, nonadmin_username):
-    user_id = ansible_engine.shell(f"ovirt-aaa-jdbc-tool user show {nonadmin_username} --attribute=id")[
-        'stdout_lines'
-    ][0]
+def test_add_nonadmin_keycloak_user(
+    engine_api,
+    engine_api_url,
+    ansible_engine,
+    ost_images_distro,
+    keycloak_auth_url,
+    keycloak_admin_username,
+    keycloak_admin_password,
+    keycloak_master_realm,
+    keycloak_ovirt_realm,
+    keycloak_profile,
+    nonadmin_username,
+    nonadmin_password,
+    keycloak_enabled,
+):
+    if not keycloak_enabled:
+        pytest.skip(' [2022-04-04] Internal Keycloak authentication disabled. Skipping Keycloak tests')
+
+    keycloak.setup_truststore(ansible_engine)
+
+    keycloak.authenticate(
+        ansible_engine=ansible_engine,
+        auth_server_url=keycloak_auth_url,
+        realm=keycloak_master_realm,
+        user=keycloak_admin_username,
+        passwd=nonadmin_password,
+    )
+
+    keycloak.create_user(
+        ansible_engine=ansible_engine,
+        realm=keycloak_ovirt_realm,
+        username=nonadmin_username,
+        password=nonadmin_password,
+    )
+
+    # for externally handled users (ie. via Keycloak) it is required to attempt to login or access rest api
+    # so that internal representation of the user be created in engine db
+    keycloak.activate_user(
+        engine_api_url=engine_api_url, username=nonadmin_username, password=nonadmin_password, profile=keycloak_profile
+    )
+
+    # TODO extract that user id resolving to utils
+    # duplication in 'test_add_nonadmin_keycloak_user'
+    user_id = None
+    users = engine_api.system_service().users_service().list()
+    for u in users:
+        if u.principal == nonadmin_username:
+            user_id = u.id
+    assert user_id is not None
+
+
+@order_by(_TEST_LIST)
+def test_add_vm_permissions_to_user(engine_api, ansible_engine, nonadmin_username, keycloak_enabled):
+    if keycloak_enabled:
+        users = engine_api.system_service().users_service().list()
+        user_id = None
+        for u in users:
+            if u.principal == nonadmin_username:
+                user_id = u.id
+        nonadmin_user = types.User(
+            id=user_id,
+            domain=types.Domain(name='internalkeycloak-authz'),
+            principal=nonadmin_username,
+        )
+    else:
+        user_id = ansible_engine.shell(f"ovirt-aaa-jdbc-tool user show {nonadmin_username} --attribute=id")[
+            'stdout_lines'
+        ][0]
+        nonadmin_user = types.User(
+            id=user_id,
+            domain=types.Domain(name='internal-authz'),
+            principal=nonadmin_username,
+        )
+
     vms_service = engine_api.system_service().vms_service()
     vm = vms_service.list(search='name=vm0')[0]
     permissions_service = vms_service.vm_service(vm.id).permissions_service()
     with engine_utils.wait_for_event(engine_api.system_service(), 850):  # PERMISSION_ADD(850)
         permissions_service.add(
             types.Permission(
-                user=types.User(
-                    id=user_id,
-                ),
+                user=nonadmin_user,
                 role=types.Role(
                     name='UserRole',
                 ),

--- a/basic-suite-master/test-scenarios/test_100_basic_ui_sanity.py
+++ b/basic-suite-master/test-scenarios/test_100_basic_ui_sanity.py
@@ -265,9 +265,9 @@ def after_test(request, save_screenshot, save_page_source, save_logs_from_browse
 
 
 @pytest.fixture(scope="session")
-def user_login(ovirt_driver):
+def user_login(ovirt_driver, keycloak_enabled):
     def login(username, password):
-        login_screen = LoginScreen(ovirt_driver)
+        login_screen = LoginScreen(ovirt_driver, keycloak_enabled)
         login_screen.wait_for_displayed()
         login_screen.set_user_name(username)
         login_screen.set_user_password(password)
@@ -301,6 +301,7 @@ def test_login(
     engine_username,
     engine_password,
     engine_cert,
+    keycloak_enabled,
 ):
 
     save_screenshot('welcome-screen')
@@ -309,7 +310,7 @@ def test_login(
     welcome_screen.wait_for_displayed()
     welcome_screen.open_administration_portal()
 
-    login_screen = LoginScreen(ovirt_driver)
+    login_screen = LoginScreen(ovirt_driver, keycloak_enabled)
     login_screen.wait_for_displayed()
     login_screen.set_user_name(engine_username)
     login_screen.set_user_password(engine_password)

--- a/ost_utils/keycloak.py
+++ b/ost_utils/keycloak.py
@@ -1,0 +1,43 @@
+#
+# Copyright oVirt Authors
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+#
+
+
+import ovirtsdk4 as sdk4
+
+# Keycloak
+KCADM = 'KC_OPTS="-Dcom.redhat.fips=false " /usr/share/ovirt-engine-wildfly/bin/kcadm.sh'
+
+
+def setup_truststore(ansible_engine):
+    ansible_engine.shell(f'{KCADM} config truststore --trustpass mypass /etc/pki/ovirt-engine/.truststore')
+
+
+def authenticate(ansible_engine, auth_server_url, realm, user, passwd):
+    ansible_engine.shell(
+        f'{KCADM} config credentials '
+        f'--server {auth_server_url} '
+        f'--realm {realm} '
+        f'--user {user} '
+        f'--password {passwd}'
+    )
+
+
+def create_user(ansible_engine, realm, username, password):
+    ansible_engine.shell(f'{KCADM} create users -r {realm} -s username={username} -s enabled=true')
+    ansible_engine.shell(f'{KCADM} set-password -r {realm} --username {username} --new-password {password}')
+
+
+def activate_user(engine_api_url, username, password, profile):
+    # In order to sync Keycloak user with Engine db we need at least an attempt to authenticate
+    # and access some protected resources
+    api = sdk4.Connection(
+        url=engine_api_url,
+        username=f'{username}@{profile}',
+        password=password,
+        insecure=True,
+        debug=True,
+    )
+    api.test(raise_exception=False)

--- a/ost_utils/keycloak.py
+++ b/ost_utils/keycloak.py
@@ -15,13 +15,13 @@ def setup_truststore(ansible_engine):
     ansible_engine.shell(f'{KCADM} config truststore --trustpass mypass /etc/pki/ovirt-engine/.truststore')
 
 
-def authenticate(ansible_engine, auth_server_url, realm, user, passwd):
+def authenticate(ansible_engine, auth_server_url, realm, user, password):
     ansible_engine.shell(
         f'{KCADM} config credentials '
         f'--server {auth_server_url} '
         f'--realm {realm} '
         f'--user {user} '
-        f'--password {passwd}'
+        f'--password {password}'
     )
 
 
@@ -41,3 +41,11 @@ def activate_user(engine_api_url, username, password, profile):
         debug=True,
     )
     api.test(raise_exception=False)
+
+
+def resolve_user_id(engine_api, username):
+    users = engine_api.system_service().users_service().list()
+    for u in users:
+        if u.principal == username:
+            return u.id
+    return None

--- a/ost_utils/pytest/fixtures/engine.py
+++ b/ost_utils/pytest/fixtures/engine.py
@@ -57,13 +57,28 @@ def engine_webadmin_url(engine_fqdn):
 
 
 @pytest.fixture(scope="session")
-def engine_username():
+def keycloak_enabled(ost_images_distro):
+    # internally bundled Keycloak authentication is by default (via engine-setup) enabled only for upstream (el8stream)
+    # downstream (rhel) still depends on legacy AAA. Keycloak authentication can still be enabled manually
+    return ost_images_distro != 'rhel8'
+
+
+@pytest.fixture(scope="session")
+def engine_username(keycloak_enabled):
+    if keycloak_enabled:
+        return "admin@ovirt"
+
+    # use legacy AAA authentication for rhel
     return "admin"
 
 
 @pytest.fixture(scope="session")
-def engine_full_username():
-    return "admin@internal"
+def engine_full_username(keycloak_enabled):
+    if keycloak_enabled:
+        return "admin@ovirt@internalsso"
+
+    # use legacy AAA authentication for rhel
+    return 'admin@internal'
 
 
 @pytest.fixture(scope="session")

--- a/ost_utils/pytest/fixtures/engine.py
+++ b/ost_utils/pytest/fixtures/engine.py
@@ -10,6 +10,7 @@ import tempfile
 import time
 
 import ovirtsdk4 as sdk4
+import ovirtsdk4.types as types
 import pytest
 
 from ost_utils import assert_utils
@@ -79,6 +80,15 @@ def engine_full_username(keycloak_enabled):
 
     # use legacy AAA authentication for rhel
     return 'admin@internal'
+
+
+@pytest.fixture(scope="session")
+def engine_user_domain(keycloak_enabled):
+    if keycloak_enabled:
+        return types.Domain(name='internalkeycloak-authz')
+
+    # use legacy AAA authentication for rhel
+    return types.Domain(name='internal-authz')
 
 
 @pytest.fixture(scope="session")

--- a/ost_utils/pytest/fixtures/keycloak.py
+++ b/ost_utils/pytest/fixtures/keycloak.py
@@ -1,0 +1,38 @@
+#
+# Copyright oVirt Authors
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+#
+
+import pytest
+
+
+@pytest.fixture(scope="session")
+def keycloak_auth_url(engine_fqdn):
+    return f"https://{engine_fqdn}/ovirt-engine-auth"
+
+
+@pytest.fixture(scope="session")
+def keycloak_admin_username():
+    return "admin"
+
+
+@pytest.fixture(scope="session")
+def keycloak_admin_password(engine_password):
+    # By default password is the same as admin administrator password
+    return engine_password
+
+
+@pytest.fixture(scope="session")
+def keycloak_ovirt_realm():
+    return "ovirt-internal"
+
+
+@pytest.fixture(scope="session")
+def keycloak_profile():
+    return "internalsso"
+
+
+@pytest.fixture(scope="session")
+def keycloak_master_realm():
+    return "master"

--- a/ost_utils/pytest/fixtures/sdk.py
+++ b/ost_utils/pytest/fixtures/sdk.py
@@ -76,11 +76,15 @@ def users_service(system_service):
 
 @pytest.fixture(scope="session")
 def get_user_service_for_user(users_service):
-    def service_for(username):
-        users = users_service.list(search=f'name={username}')
-        if len(users) != 1:
-            raise RuntimeError("Could not find user: {}".format(username))
-        return users_service.user_service(users[0].id)
+    def service_for(principal):
+        users = users_service.list()
+        user_id = None
+        for u in users:
+            if u.principal == principal:
+                user_id = u.id
+        if not user_id:
+            raise RuntimeError(f"Could not find user: {principal} [principal]")
+        return users_service.user_service(user_id)
 
     return service_for
 

--- a/ost_utils/pytest/fixtures/sdk.py
+++ b/ost_utils/pytest/fixtures/sdk.py
@@ -82,7 +82,7 @@ def get_user_service_for_user(users_service):
         for u in users:
             if u.principal == principal:
                 user_id = u.id
-        if not user_id:
+        if user_id is None:
             raise RuntimeError(f"Could not find user: {principal} [principal]")
         return users_service.user_service(user_id)
 

--- a/ost_utils/selenium/page_objects/LoginScreen.py
+++ b/ost_utils/selenium/page_objects/LoginScreen.py
@@ -11,8 +11,9 @@ LOGGER = logging.getLogger(__name__)
 
 
 class LoginScreen(Displayable):
-    def __init__(self, ovirt_driver):
+    def __init__(self, ovirt_driver, keycloak_enabled):
         super(LoginScreen, self).__init__(ovirt_driver)
+        self._keycloak_enabled = keycloak_enabled
 
     def is_displayed(self):
         is_user_name_displayed = self.ovirt_driver.driver.find_element(
@@ -42,4 +43,7 @@ class LoginScreen(Displayable):
 
     def login(self):
         LOGGER.debug('Log in')
-        self.ovirt_driver.xpath_click('//form[@id="loginForm"]//button')
+        if self._keycloak_enabled:
+            self.ovirt_driver.xpath_click('//input[@id="kc-login"]')
+        else:
+            self.ovirt_driver.xpath_click('//form[@id="loginForm"]//button')


### PR DESCRIPTION
This patch allows to test ovirt engine running with authentication
configured around internally bundled instance of Keycloak (OpenID
Protocol) that is deprecating AAA modules.

!! Work in progress - do not merge it yet !!