### PR TITLE
deploy: Disable fapolicyd during upgrade

### DIFF
--- a/common/deploy-scripts/setup_first_he_host.sh
+++ b/common/deploy-scripts/setup_first_he_host.sh
@@ -67,6 +67,15 @@ dnf_update() {
   copy:
     src: /etc/yum.repos.d
     dest: /etc
+- name: Check fapolicyd status, remove once BZ#2070036 is fixed
+  systemd:
+    name: fapolicyd
+  register: fapolicyd_status
+- name: Stop fapolicyd, remove once BZ#2070036 is fixed
+  systemd:
+    name: fapolicyd
+    state: stopped
+  when: fapolicyd_status.status.SubState == 'running'
 - name: DNF update the system. TODO remove baseos&appstream once RHV appliance is regularly up to date.
   dnf:
     name:  "*"
@@ -76,6 +85,11 @@ dnf_update() {
     exclude:
       - ovirt-release-master
       - ovirt-release-master-tested
+- name: Start fapolicyd, remove once BZ#2070036 is fixed
+  systemd:
+    name: fapolicyd
+    state: started
+  when: fapolicyd_status.status.SubState == 'running'
 EOF
 
 }

--- a/ost_utils/pytest/fixtures/deployment.py
+++ b/ost_utils/pytest/fixtures/deployment.py
@@ -138,8 +138,11 @@ def deploy(
         repo_urls = package_mgmt.expand_repos(custom_repos, working_dir, ost_images_distro)
         package_mgmt.add_custom_repos(ansible_vms_to_deploy, repo_urls)
         # TODO remove --nobest when the engine works with ansible-core
+        # TODO: Remove once BZ#2070036 is fixed
         ansible_vms_to_deploy.shell(
-            'dnf upgrade --nogpgcheck -y --disableplugin versionlock -x ovirt-release-master,ovirt-release-master-tested,ovirt-engine-appliance,rhvm-appliance,ovirt-node-ng-image-update,redhat-virtualization-host-image-update --nobest'
+            '[ "$(systemctl is-enabled fapolicyd)" = "enabled" ] && systemctl stop fapolicyd || true;'
+            'dnf upgrade --nogpgcheck -y --disableplugin versionlock -x ovirt-release-master,ovirt-release-master-tested,ovirt-engine-appliance,rhvm-appliance,ovirt-node-ng-image-update,redhat-virtualization-host-image-update --nobest;'
+            '[ "$(systemctl is-enabled fapolicyd)" = "enabled" ] && systemctl start fapolicyd || true;'
         )
         # check if packages from custom repos were used
         if not request.config.getoption('--skip-custom-repos-check'):


### PR DESCRIPTION
Due to the bug with fapolicyd corrupting initramfs [0],
disable fapolicyd during upgrades.

[0] https://bugzilla.redhat.com/2070036

Signed-off-by: Ales Musil <amusil@redhat.com>