### PR TITLE
jenkins: add exception for tr-suite-master

### DIFF
--- a/.github/jenkins
+++ b/.github/jenkins
@@ -96,6 +96,7 @@ OST_REFSPEC=$OST_REFSPEC
 CUSTOM_REPOS=$CUSTOM_REPOS
 CUSTOM_OST_IMAGES_REPO=$CUSTOM_OST_IMAGES_REPO
 EOF
+    [[ "$SUITE" = "tr-suite-master" ]] && echo "DONT_CHECK_IF_REPOSITORIES_WERE_USED=true" >> vars
     cat vars
 else # after actual OST, with injected vars
     echo processing results


### PR DESCRIPTION
packages are not preinstalled so when a PR is passed the verification
that it has been used would fail. Let's always skip that check and rely
on the suite tests to do the right thing (install whatever is needed)
