### PR TITLE
tr: skip terraform tests and run go-ovirt-client instead

### DIFF
--- a/common/deploy-scripts/setup_tr_suite.sh
+++ b/common/deploy-scripts/setup_tr_suite.sh
@@ -1,0 +1,5 @@
+#!/bin/bash -xe
+
+# custom repo containing tests must be added 
+dnf install -y go-ovirt-client-tests 
+

--- a/tr-suite-master/ost.json
+++ b/tr-suite-master/ost.json
@@ -34,7 +34,8 @@
     "memory": "3584",
     "deploy-scripts": [
       "common/deploy-scripts/setup_storage.sh",
-      "common/deploy-scripts/setup_engine.sh"
+      "common/deploy-scripts/setup_engine.sh",
+      "common/deploy-scripts/setup_tr_suite.sh"
     ],
     "nics": {
       "engine": { "template": "common/libvirt-templates/nic_template" },

--- a/tr-suite-master/test-scenarios/test_0001_check_installed_packages.py
+++ b/tr-suite-master/test-scenarios/test_0001_check_installed_packages.py
@@ -12,6 +12,7 @@ from ost_utils.pytest.fixtures.engine import *
 from ost_utils.pytest.fixtures.env import suite_dir
 
 def test_check_installed_packages(ansible_engine, suite_dir):
+    pytest.skip('Skip terraform')
     working_dir = '/usr/local/bin'
     func = "func.sh"
     script = 'test-check-installed-packages.sh'

--- a/tr-suite-master/test-scenarios/test_0002_init_terraform.py
+++ b/tr-suite-master/test-scenarios/test_0002_init_terraform.py
@@ -12,6 +12,7 @@ from ost_utils.pytest.fixtures.engine import *
 from ost_utils.pytest.fixtures.env import suite_dir
 
 def test_init_terraform(ansible_engine, suite_dir):
+    pytest.skip('Skip terraform')
     plugin_dir = '/usr/local/bin'
     script = 'test-init-terraform.sh'
 

--- a/tr-suite-master/test-scenarios/test_002_ansible.py
+++ b/tr-suite-master/test-scenarios/test_002_ansible.py
@@ -32,7 +32,7 @@ def test_ansible_run(
                 "description": "APIv4 Cluster",
                 "scheduling_policy": "evenly_distributed",
                 "profile": "my_cpu_profile",
-                "cpu_arch": "ppc64",
+                "cpu_arch": "x86_64",
                 "cpu_type": "",
                 "ksm": "yes",
                 "ksm_numa": "yes",
@@ -79,24 +79,6 @@ def test_ansible_run(
                 },
             },
         },
-        logical_networks=[
-            {
-                "name": "Migration_Net",
-                "description": "Non VM Network on VLAN 200, MTU 9000",
-                "mtu": 9000,
-                "vlan_tag": 200,
-                "clusters": [
-                    {
-                        "name": "test-cluster",
-                        "assigned": True,
-                        "migration": True,
-                        "required": False,
-                        "display": False,
-                        "gluster": False,
-                    }
-                ],
-            }
-        ],
         mac_pools=[
             {
                 "mac_pool_name": "mymacpool",
@@ -105,30 +87,4 @@ def test_ansible_run(
                 ],
             }
         ],
-    )
-
-    collection = CollectionMapper(ansible_engine)
-
-    ovirt_auth = collection.ovirt_auth(
-        hostname=engine_ip_url,
-        username=engine_full_username,
-        password=engine_password,
-        insecure="true",
-    )['ansible_facts']['ovirt_auth']
-
-    collection.ovirt_host_info(auth=ovirt_auth, pattern="name=*")
-
-    collection.ovirt_vm(
-        auth=ovirt_auth,
-        name="rhel",
-        cluster="test-cluster",
-        memory="1GiB",
-        cloud_init={"user_name": 'root', 'root_password': 'super_password'},
-        cloud_init_persist="true",
-    )
-
-    # Revoke the SSO token
-    collection.ovirt_auth(
-        state="absent",
-        ovirt_auth=ovirt_auth,
     )

--- a/tr-suite-master/test-scenarios/test_003_go_ovirt_client.py
+++ b/tr-suite-master/test-scenarios/test_003_go_ovirt_client.py
@@ -15,6 +15,6 @@ def test_run_go_ovirt_client_tests(ansible_engine, engine_api_url,
                            engine_full_username, engine_password):
 
     ansible_engine.shell(
-        f'OVIRT_INSECURE=1 OVIRT_URL={engine_api_url} OVIRT_USERNAME=${engine_full_username} OVIRT_PASSWRD=${engine_password} go-ovirt-client-tests-exe -test.v'
+        f'OVIRT_CA_FILE=/etc/pki/ovirt-engine/ca.pem OVIRT_URL={engine_api_url} OVIRT_USERNAME=${engine_full_username} OVIRT_PASSWRD=${engine_password} go-ovirt-client-tests-exe -test.v'
     )
 

--- a/tr-suite-master/test-scenarios/test_003_go_ovirt_client.py
+++ b/tr-suite-master/test-scenarios/test_003_go_ovirt_client.py
@@ -1,0 +1,20 @@
+#
+# Copyright oVirt Authors
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# -*- coding: utf-8 -*-
+#
+
+from os import environ, path
+
+from ost_utils.pytest.fixtures.ansible import *
+from ost_utils.pytest.fixtures.engine import *
+from ost_utils.pytest.fixtures.env import suite_dir
+
+def test_run_go_ovirt_client_tests(ansible_engine, engine_api_url,
+                           engine_full_username, engine_password):
+
+    ansible_engine.shell(
+        f'OVIRT_INSECURE=1 OVIRT_URL={engine_api_url} OVIRT_USERNAME=${engine_full_username} OVIRT_PASSWRD=${engine_password} go-ovirt-client-tests-exe -test.v'
+    )
+

--- a/tr-suite-master/test-scenarios/test_004_run_ocp_installer.py
+++ b/tr-suite-master/test-scenarios/test_004_run_ocp_installer.py
@@ -17,6 +17,7 @@ from ost_utils import shell
 def test_run_ocp_installer(ansible_engine, engine_api, engine_fqdn, engine_api_url,
                            engine_full_username, engine_password, suite_dir):
 
+    pytest.skip('Skip terraform')
     working_dir = '/usr/local/bin'
     openshift_dir = '/usr/bin'
     dc_name = 'test-dc'


### PR DESCRIPTION
go-ovirt-client tests are working (unlike terraform ATM), so let's run
them!
