### PR TITLE
add ansible-runner temp directory to collected artifacts

### DIFF
--- a/ost_utils/pytest/fixtures/artifacts.py
+++ b/ost_utils/pytest/fixtures/artifacts.py
@@ -49,6 +49,7 @@ def artifact_list():
         '/tmp/dnf_yum.conf',
         '/var/cache/ovirt-engine',
         '/var/lib/ovirt-engine/setup/answers',
+        '/var/lib/ovirt-engine/ansible-runner',
         '/var/lib/pgsql/initdb_postgresql.log',
         '/var/lib/pgsql/data/log',
         '/var/log',


### PR DESCRIPTION
ansible is often broken, let's see what it tries to hide...
