### PR TITLE
Fix keycloak_enabled logic

### DIFF
--- a/he-basic-suite-master/test-scenarios/conftest.py
+++ b/he-basic-suite-master/test-scenarios/conftest.py
@@ -23,6 +23,7 @@ from ost_utils.pytest.fixtures.deployment import set_sar_interval
 from ost_utils.pytest.fixtures.engine import *
 from ost_utils.pytest.fixtures.env import *
 from ost_utils.pytest.fixtures.he import *
+from ost_utils.pytest.fixtures.keycloak import *
 from ost_utils.pytest.fixtures.network import *
 from ost_utils.pytest.fixtures.node import *
 from ost_utils.pytest.fixtures.sdk import *

--- a/ost_utils/pytest/fixtures/engine.py
+++ b/ost_utils/pytest/fixtures/engine.py
@@ -58,10 +58,13 @@ def engine_webadmin_url(engine_fqdn):
 
 
 @pytest.fixture(scope="session")
-def keycloak_enabled(ost_images_distro):
-    # internally bundled Keycloak authentication is by default (via engine-setup) enabled only for upstream (el8stream)
-    # downstream (rhel) still depends on legacy AAA. Keycloak authentication can still be enabled manually
-    return ost_images_distro != 'rhel8'
+def keycloak_enabled(ansible_engine):
+    return (
+        ansible_engine.shell(
+            'otopi-config-query query -k OVESETUP_KEYCLOAK_CORE/enable -f /etc/ovirt-engine-setup.conf'
+        )['stdout_lines'][0].lower()
+        == 'true'
+    )
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
Without this patch, it fails on hosted-engine, where we currently
disabled it. Change the logic to check inside the engine machine instead
of guessing.

Change-Id: I681038351471af4747f61ed017fbf8c8e9a8d52a
Signed-off-by: Yedidyah Bar David <didi@redhat.com>