### PR TITLE
Network suite: remove duplicated fixtures

### DIFF
--- a/network-suite-master/fixtures/engine.py
+++ b/network-suite-master/fixtures/engine.py
@@ -15,42 +15,14 @@ from ovirtlib import userlib
 
 
 @pytest.fixture(scope="session")
-def keycloak_enabled(ost_images_distro):
-    # internally bundled Keycloak authentication is by default (via engine-setup) enabled only for upstream (el8stream)
-    # downstream (rhel) still depends on legacy AAA. Keycloak authentication can still be enabled manually
-    return ost_images_distro != 'rhel8'
-
-
-@pytest.fixture(scope="session")
-def engine_admin_username(keycloak_enabled):
-    if keycloak_enabled:
-        return "admin@ovirt"
-
-    return "admin"
-
-
-@pytest.fixture(scope="session")
-def engine_authentication_profile(keycloak_enabled):
-    if keycloak_enabled:
-        return "internalsso"
-
-    return "internal"
-
-
-@pytest.fixture(scope="session")
-def engine_full_username(engine_admin_username, engine_authentication_profile):
-    return f"{engine_admin_username}@{engine_authentication_profile}"
-
-
-@pytest.fixture(scope="session")
 def engine_password():
     return "123"
 
 
 @pytest.fixture(scope="session")
-def admin_user(system, engine_admin_username):
+def admin_user(system, engine_username):
     admin = userlib.User(system)
-    admin.import_by_name(engine_admin_username)
+    admin.import_by_name(engine_username)
     return admin
 
 

--- a/network-suite-master/test-scenarios/conftest.py
+++ b/network-suite-master/test-scenarios/conftest.py
@@ -23,11 +23,7 @@ from fixtures.host import host_1_up
 from fixtures.host import install_hosts_to_save_time
 
 from fixtures.engine import admin_user
-from fixtures.engine import engine_admin_username
-from fixtures.engine import engine_authentication_profile
-from fixtures.engine import engine_full_username
 from fixtures.engine import engine_password
-from fixtures.engine import keycloak_enabled
 from fixtures.engine import ovirt_engine_setup
 from fixtures.engine import ovirt_engine_service_up
 from fixtures.engine import api
@@ -87,10 +83,12 @@ from ost_utils.pytest.fixtures.engine import engine_admin_service
 from ost_utils.pytest.fixtures.engine import engine_answer_file_contents
 from ost_utils.pytest.fixtures.engine import engine_answer_file_path
 from ost_utils.pytest.fixtures.engine import engine_fqdn
+from ost_utils.pytest.fixtures.engine import engine_full_username
 from ost_utils.pytest.fixtures.engine import engine_ip
 from ost_utils.pytest.fixtures.engine import engine_ip_url
 from ost_utils.pytest.fixtures.engine import engine_ips_for_network
 from ost_utils.pytest.fixtures.engine import engine_username
+from ost_utils.pytest.fixtures.engine import keycloak_enabled
 from ost_utils.pytest.fixtures.env import ost_images_distro
 from ost_utils.pytest.fixtures.env import root_dir
 from ost_utils.pytest.fixtures.env import ssh_key_file


### PR DESCRIPTION
Some of the required fixtures are already available in ```ost_utils/pytest/fixtures/engine.py```

This patch removes duplicates and adds relevant imports.