### PR TITLE
Fix keycloak_enabled to work better

### DIFF
--- a/ost_utils/pytest/fixtures/engine.py
+++ b/ost_utils/pytest/fixtures/engine.py
@@ -60,15 +60,14 @@ def engine_webadmin_url(engine_fqdn):
 
 @pytest.fixture(scope="session")
 def keycloak_enabled(ansible_engine):
-    try:
-        return (
-            ansible_engine.shell(
-                'otopi-config-query query -k OVESETUP_KEYCLOAK_CORE/enable -f /etc/ovirt-engine-setup.conf'
-            )['stdout_lines'][0].lower()
-            == 'true'
-        )
-    except AnsibleExecutionError:
-        return False
+    return (
+        ansible_engine.shell(
+            'grep -hsR ^OVESETUP_KEYCLOAK_CORE/enable /etc/ovirt-engine-setup.conf /etc/ovirt-engine-setup.conf.d || :'
+        )['stdout']
+        .lower()
+        .strip()
+        .endswith('true')
+    )
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
otopi-config-query is great, but sometimes we have a single
config, sometimes we use conf.d subdirectory. KISS and just grep.
