### PR TITLE
he: drop ansible upgrade workaround

### DIFF
--- a/common/deploy-scripts/setup_first_he_host.sh
+++ b/common/deploy-scripts/setup_first_he_host.sh
@@ -68,7 +68,7 @@ dnf_update() {
     src: /etc/yum.repos.d
     dest: /etc
 - name: DNF update the system for RHV. TODO remove once RHV appliance is regularly up to date.
-  shell: rpm -e --nodeps ansible; dnf update -y --repo rhel*,rhv*
+  shell: dnf update -y --disableplugin versionlock --repo rhel*,rhv*
   ignore_errors: yes
 EOF
 


### PR DESCRIPTION
Appliance rhvm-appliance-4.5-20220407 has ansible-core, no need for
ansible uninstallation
