### PR TITLE
basic: remove async_ argument when calling ExternalVmImportService

### DIFF
--- a/basic-suite-master/test-scenarios/test_004_basic_sanity.py
+++ b/basic-suite-master/test-scenarios/test_004_basic_sanity.py
@@ -792,7 +792,6 @@ def test_import_vm_preallocated(engine_api, ost_cluster_name):
                 storage_domain=types.StorageDomain(id=sd.id),
                 host=types.Host(id=host.id),
             ),
-            async_=True,
             query={'correlation_id': correlation_id},
         )
 


### PR DESCRIPTION
There is no `async_` argument for the `add()` call in `ExternalVmImportService`. The argument is silently ignored and having that in the call is misleading/confusing to anyone reading the code.

Signed-off-by: Tomáš Golembiovský <tgolembi@redhat.com>