### PR TITLE
basic: enable storage vm for ldap

### DIFF
--- a/basic-suite-master/test-scenarios/test_099_aaa-ldap.py
+++ b/basic-suite-master/test-scenarios/test_099_aaa-ldap.py
@@ -14,14 +14,16 @@ import pytest
 from ost_utils import engine_utils
 
 # AAA
+from ost_utils.pytest.fixtures.ansible import ansible_storage
+
 AAA_LDAP_USER = 'user1'
 AAA_LDAP_GROUP = 'mygroup'
 AAA_LDAP_AUTHZ_PROVIDER = 'lago.local-authz'
 
 
 @pytest.fixture(scope="session")
-def ansible_machine_389ds(ansible_engine):
-    return ansible_engine
+def ansible_machine_389ds(ansible_storage):
+    return ansible_storage
 
 
 @pytest.fixture(scope="session")

--- a/common/init-configs/1_engine_2_hosts.json
+++ b/common/init-configs/1_engine_2_hosts.json
@@ -35,7 +35,6 @@
     "template": "common/libvirt-templates/vm_template",
     "memory": "3584",
     "deploy-scripts": [
-      "common/deploy-scripts/setup_storage.sh",
       "common/deploy-scripts/setup_engine.sh"
     ],
     "nics": {


### PR DESCRIPTION
Migrating the storage vm to a separate vm from the engine
also included moving the Ldap service to the storage vm.