### PR TITLE
he: test_008_restart_he_vm: Give the vm more time to shutdown

### DIFF
--- a/he-basic-suite-master/test-scenarios/test_008_restart_he_vm.py
+++ b/he-basic-suite-master/test-scenarios/test_008_restart_he_vm.py
@@ -48,7 +48,7 @@ def test_clear_global_maintenance(ansible_host0):
 def _shutdown_he_vm(ansible_host):
     ansible_host.shell('hosted-engine --vm-shutdown')
     logging.info('Waiting for the engine VM to be down...')
-    assert assert_utils.true_within_short(lambda: he_utils.engine_vm_is_down(ansible_host))
+    assert assert_utils.true_within_long(lambda: he_utils.engine_vm_is_down(ansible_host))
 
 
 def _restart_services(ansible_host):


### PR DESCRIPTION
Some times, a short (3 minutes) timeout is not enough, in CI.

Change-Id: I63838b39820a63eae835809f93d30028f420cd98
Signed-off-by: Yedidyah Bar David <didi@redhat.com>