### PR TITLE
engine: Disable usage of keycloak

### DIFF
--- a/ost_utils/pytest/fixtures/engine.py
+++ b/ost_utils/pytest/fixtures/engine.py
@@ -60,9 +60,8 @@ def engine_webadmin_url(engine_fqdn):
 
 @pytest.fixture(scope="session")
 def keycloak_enabled(ost_images_distro, suite):
-    # internally bundled Keycloak authentication is by default (via engine-setup) enabled only for upstream (el8stream)
-    # downstream (rhel) still depends on legacy AAA. Keycloak authentication can still be enabled manually
-    return ost_images_distro != 'rhel8' and suite != 'he-basic-suite-master'
+    # turn back on when engine starts using keycloak
+    return False
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
With [1] we've disabled keycloak integration for now.

[1] https://github.com/oVirt/ovirt-engine/pull/273

Signed-off-by: Marcin Sobczyk <msobczyk@redhat.com>
