### PR TITLE
ost: remove storage disks from engine vm

### DIFF
--- a/common/init-configs/1_engine_2_hosts.json
+++ b/common/init-configs/1_engine_2_hosts.json
@@ -42,18 +42,7 @@
       "engine-storage": { "template": "common/libvirt-templates/nic_template" }
     },
     "root_disk_var": "OST_IMAGES_ENGINE_INSTALLED",
-    "disks": {
-      "sda": {
-        "comment": "Main NFS device",
-        "template": "common/libvirt-templates/disk_template",
-        "size": "101G"
-      },
-      "sdc": {
-        "comment": "Main iSCSI device",
-        "template": "common/libvirt-templates/disk_template",
-        "size": "105G"
-      }
-    }
+    "disks": {}
   },
   "storage": {
     "template": "common/libvirt-templates/vm_template",


### PR DESCRIPTION
remove storage disks from engine vm as all storage moved to the storage vm.