### PR TITLE
Add missing fixture

### DIFF
--- a/ansible-suite-master/test-scenarios/conftest.py
+++ b/ansible-suite-master/test-scenarios/conftest.py
@@ -27,6 +27,7 @@ from ost_utils.pytest.fixtures.backend import management_network_supports_ipv4
 from ost_utils.pytest.fixtures.backend import storage_hostname
 
 from ost_utils.pytest.fixtures.defaults import ansible_vms_to_deploy
+from ost_utils.pytest.fixtures.defaults import deploy_hosted_engine
 from ost_utils.pytest.fixtures.defaults import hostnames_to_add
 
 from ost_utils.pytest.fixtures.deployment import deploy

--- a/network-suite-master/test-scenarios/conftest.py
+++ b/network-suite-master/test-scenarios/conftest.py
@@ -77,6 +77,7 @@ from ost_utils.pytest.fixtures.backend import storage_hostname
 from ost_utils.pytest.fixtures.backend import management_network_supports_ipv4
 from ost_utils.pytest.fixtures.backend import tested_ip_version
 from ost_utils.pytest.fixtures.defaults import ansible_vms_to_deploy
+from ost_utils.pytest.fixtures.defaults import deploy_hosted_engine
 from ost_utils.pytest.fixtures.deployment import deploy
 from ost_utils.pytest.fixtures.deployment import run_scripts
 from ost_utils.pytest.fixtures.deployment import set_sar_interval


### PR DESCRIPTION
We need to have the 'deploy_hosted_engine' fixture in scope
after merging delayed repo check for HE [1].

[1] https://github.com/oVirt/ovirt-system-tests/pull/31

Signed-off-by: Marcin Sobczyk <msobczyk@redhat.com>
