### PR TITLE
storage: Bump RAM to 2048M

### DIFF
--- a/common/init-configs/1_engine_2_hosts.json
+++ b/common/init-configs/1_engine_2_hosts.json
@@ -46,7 +46,7 @@
   },
   "storage": {
     "template": "common/libvirt-templates/vm_template",
-    "memory": "1792",
+    "memory": "2048",
     "deploy-scripts": [
       "common/deploy-scripts/setup_storage.sh"
     ],


### PR DESCRIPTION
We're seeing crashes on Selenium grid startup probably caused by
insufficient amount of resources. Let's try bumping the RAM a bit.

Signed-off-by: Marcin Sobczyk <msobczyk@redhat.com>
