### PR TITLE
selenium: Use "latest" browser versions

### DIFF
--- a/basic-suite-master/test-scenarios/test_100_basic_ui_sanity.py
+++ b/basic-suite-master/test-scenarios/test_100_basic_ui_sanity.py
@@ -47,8 +47,8 @@ from ost_utils.shell import shell
 LOGGER = logging.getLogger(__name__)
 
 
-CHROME_VERSION = '94.0.4606.81'
-FIREFOX_VERSION = '93.0'
+CHROME_VERSION = 'latest'
+FIREFOX_VERSION = 'latest'
 BROWSER_PLATFORM = 'LINUX'
 SCREEN_WIDTH = 1600
 SCREEN_HEIGHT = 900


### PR DESCRIPTION
To avoid the necessity to sync browser versions in OST with
automatically updated Selenium grid images in ost-images we're switching
to "latest" browser versions.

Signed-off-by: Marcin Sobczyk <msobczyk@redhat.com>
