### PR TITLE
lagofy: Fix ansible-galaxy setup

### DIFF
--- a/lagofy.sh
+++ b/lagofy.sh
@@ -340,7 +340,7 @@ ost_check_dependencies() {
         namei -vm `pwd`
         return 8
     }
-    (source /etc/os-release; [[ $VERSION == 9* ]]) && { ansible-galaxy collection install community.general openstack.cloud >/dev/null || {
+    rpm -q ansible-core &> /dev/null && { ansible-galaxy collection install community.general openstack.cloud >/dev/null || {
         echo "ansible collection failed"
         return 9
     }; }


### PR DESCRIPTION
8.6 uses 'ansible-core' and requires the additional galaxy packages
to be installed too.

Signed-off-by: Marcin Sobczyk <msobczyk@redhat.com>
