### PR TITLE
HE: remove ansible_vms_to_deploy

### DIFF
--- a/ansible-suite-master/test-scenarios/conftest.py
+++ b/ansible-suite-master/test-scenarios/conftest.py
@@ -26,7 +26,6 @@ from ost_utils.pytest.fixtures.backend import hosts_hostnames
 from ost_utils.pytest.fixtures.backend import management_network_supports_ipv4
 from ost_utils.pytest.fixtures.backend import storage_hostname
 
-from ost_utils.pytest.fixtures.defaults import ansible_vms_to_deploy
 from ost_utils.pytest.fixtures.defaults import deploy_hosted_engine
 from ost_utils.pytest.fixtures.defaults import hostnames_to_add
 

--- a/hc-basic-suite-master/test-scenarios/conftest.py
+++ b/hc-basic-suite-master/test-scenarios/conftest.py
@@ -28,11 +28,6 @@ from ost_utils.pytest.fixtures.storage import *
 from ost_utils.pytest.running_time import *
 
 
-@pytest.fixture(scope="session")
-def ansible_vms_to_deploy(hosts_hostnames, ansible_by_hostname):  # pylint: disable=function-redefined
-    return ansible_by_hostname(hosts_hostnames)
-
-
 # hosted-engine suites use a separate storage VM, but use the management
 # network for storage traffic. Override the relevant fixtures.
 

--- a/he-basic-suite-master/test-scenarios/conftest.py
+++ b/he-basic-suite-master/test-scenarios/conftest.py
@@ -31,13 +31,6 @@ from ost_utils.pytest.fixtures.storage import *
 from ost_utils.pytest.running_time import *
 
 
-@pytest.fixture(scope="session")
-def ansible_vms_to_deploy(
-    hosts_hostnames, storage_hostname, ansible_by_hostname
-):  # pylint: disable=function-redefined
-    return ansible_by_hostname([*hosts_hostnames, storage_hostname])
-
-
 # hosted-engine suites use a separate storage VM, but use the management
 # network for storage traffic. Override the relevant fixtures.
 

--- a/he-basic-suite-master/test-scenarios/test_001_he_deploy.py
+++ b/he-basic-suite-master/test-scenarios/test_001_he_deploy.py
@@ -41,12 +41,12 @@ def test_run_dig_loop(
 
 def test_lower_ha_agent_vdsm_connection_timeout(
     ansible_host0,
-    ansible_vms_to_deploy,
+    ansible_all,
 ):
     conspath = ansible_host0.shell(
         "python3 -c " "'from ovirt_hosted_engine_ha.env import constants; " "print(constants.__file__)'"
     )['stdout_lines'][0]
-    ansible_vms_to_deploy.lineinfile(
+    ansible_all.lineinfile(
         path=conspath,
         create=True,
         regexp='^VDSCLI_SSL_TIMEOUT',

--- a/network-suite-master/test-scenarios/conftest.py
+++ b/network-suite-master/test-scenarios/conftest.py
@@ -76,7 +76,6 @@ from ost_utils.pytest.fixtures.backend import hosts_hostnames
 from ost_utils.pytest.fixtures.backend import storage_hostname
 from ost_utils.pytest.fixtures.backend import management_network_supports_ipv4
 from ost_utils.pytest.fixtures.backend import tested_ip_version
-from ost_utils.pytest.fixtures.defaults import ansible_vms_to_deploy
 from ost_utils.pytest.fixtures.defaults import deploy_hosted_engine
 from ost_utils.pytest.fixtures.deployment import deploy
 from ost_utils.pytest.fixtures.deployment import run_scripts

--- a/ost_utils/pytest/fixtures/defaults.py
+++ b/ost_utils/pytest/fixtures/defaults.py
@@ -35,8 +35,3 @@ def hostnames_to_reboot(hosts_hostnames):
 @pytest.fixture(scope="session")
 def deploy_hosted_engine():
     return False
-
-
-@pytest.fixture(scope="session")
-def ansible_vms_to_deploy(ansible_all):
-    return ansible_all

--- a/ost_utils/pytest/fixtures/deployment.py
+++ b/ost_utils/pytest/fixtures/deployment.py
@@ -93,7 +93,7 @@ def start_sshd_proxy(vms, host, root_dir, ssh_key_file):
 
 @pytest.fixture(scope="session", autouse=True)
 def deploy(
-    ansible_vms_to_deploy,
+    ansible_all,
     ansible_hosts,
     deploy_scripts,
     deploy_hosted_engine,
@@ -113,10 +113,10 @@ def deploy(
         return
 
     LOGGER.info("Waiting for SSH on the VMs")
-    ansible_vms_to_deploy.wait_for_connection(timeout=120)
+    ansible_all.wait_for_connection(timeout=120)
 
     # set static hostname to match the one assigned by DNS
-    ansible_vms_to_deploy.shell("hostnamectl set-hostname $(hostname)")
+    ansible_all.shell("hostnamectl set-hostname $(hostname)")
 
     # start IPv6 proxy for dnf so we can update packages
     if not management_network_supports_ipv4:
@@ -124,30 +124,30 @@ def deploy(
         # can't use a fixture since VMs may not be up yet
         ip = list(backend.ip_mapping().values())[0][management_network_name][0]
         start_sshd_proxy(
-            ansible_vms_to_deploy,
+            ansible_all,
             ipaddress.ip_interface(f"{ip}/64").network[1],
             root_dir,
             ssh_key_file,
         )
 
     # disable all repos
-    package_mgmt.disable_all_repos(ansible_vms_to_deploy)
+    package_mgmt.disable_all_repos(ansible_all)
 
     # add custom repos
     custom_repos = request.config.getoption('--custom-repo')
     if custom_repos is not None:
         repo_urls = package_mgmt.expand_repos(custom_repos, working_dir, ost_images_distro)
-        package_mgmt.add_custom_repos(ansible_vms_to_deploy, repo_urls)
+        package_mgmt.add_custom_repos(ansible_all, repo_urls)
         # TODO workaround for https://bugzilla.redhat.com/show_bug.cgi?id=2077794
-        ansible_vms_to_deploy.shell(
+        ansible_all.shell(
             'dnf upgrade --nogpgcheck -y --disableplugin versionlock -x ovirt-release-master,ovirt-release-master-tested,ovirt-engine-appliance,rhvm-appliance,ovirt-node-ng-image-update,redhat-virtualization-host-image-update,postgresql-jdbc'
         )
         # check if packages from custom repos were used
         if not request.config.getoption('--skip-custom-repos-check') and not deploy_hosted_engine:
-            package_mgmt.check_installed_packages(ansible_vms_to_deploy)
+            package_mgmt.check_installed_packages(ansible_all)
 
     # report package versions
-    package_mgmt.report_ovirt_packages_versions(ansible_vms_to_deploy)
+    package_mgmt.report_ovirt_packages_versions(ansible_all)
 
     # run deployment scripts
     runs = [functools.partial(run_scripts, hostname, scripts) for hostname, scripts in deploy_scripts.items()]


### PR DESCRIPTION
In HE suite we don't want to touch engine until after HE deployment,
so in the past we used ansible_vms_to_deploy to exclude the engine.
Nowadays we add engine to ansible_all dynamically after the HE
deployment, so separate fixture is no longer needed.