### PR TITLE
vmconsole: Don't decode stdout

### DIFF
--- a/basic-suite-master/test-scenarios/test_004_basic_sanity.py
+++ b/basic-suite-master/test-scenarios/test_004_basic_sanity.py
@@ -658,7 +658,6 @@ def test_vmconsole(engine_api, engine_ip, working_dir, rsa_pair):
         stdin=slave,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        universal_newlines=True,
         bufsize=0,
     )
 
@@ -669,7 +668,7 @@ def test_vmconsole(engine_api, engine_ip, working_dir, rsa_pair):
         response = vmconsole_process.stdout.read(1)
         if len(response.strip()) != 0:
             message = response + vmconsole_process.stdout.readline()
-            if f"login as '{VM_USER_NAME}'" in message or f'{VM0_NAME} login' in message:
+            if f"login as '{VM_USER_NAME}'".encode() in message or f'{VM0_NAME} login'.encode() in message:
                 connection_success = True
                 break
         sleep(1)


### PR DESCRIPTION
By default 'Popen' processes's stdout is opened as a byte stream.
Passing the 'universal_newlines=True' argument makes the stream
automatically decoded from UTF-8.

Since we're reading the output char by char, multibyte UTF-8 characters
can break the stream with i.e.:

 E UnicodeDecodeError: 'utf-8' codec can't decode byte 0xda in position 191: invalid continuation byte

Let's change the output to have a form of bytes and use bytes in
comparisons too.

Signed-off-by: Marcin Sobczyk <msobczyk@redhat.com>
