### PR TITLE
run vms on el9

### DIFF
--- a/basic-suite-master/test-scenarios/conftest.py
+++ b/basic-suite-master/test-scenarios/conftest.py
@@ -16,6 +16,7 @@ from ost_utils.pytest.fixtures.ansible import ansible_clean_private_dirs
 from ost_utils.pytest.fixtures.ansible import ansible_collect_logs
 from ost_utils.pytest.fixtures.ansible import ansible_engine
 from ost_utils.pytest.fixtures.ansible import ansible_engine_facts
+from ost_utils.pytest.fixtures.ansible import ansible_host0_facts
 from ost_utils.pytest.fixtures.ansible import ansible_host0
 from ost_utils.pytest.fixtures.ansible import ansible_host1
 from ost_utils.pytest.fixtures.ansible import ansible_hosts

--- a/basic-suite-master/test-scenarios/test_002_bootstrap.py
+++ b/basic-suite-master/test-scenarios/test_002_bootstrap.py
@@ -1218,13 +1218,13 @@ def test_add_blank_vms(engine_api, ost_cluster_name):
             name=TEMPLATE_BLANK,
         ),
         display=sdk4.types.Display(
-            smartcard_enabled=True,
             keyboard_layout='en-us',
             file_transfer_enabled=True,
             copy_paste_enabled=True,
+            type=sdk4.types.DisplayType.VNC,
         ),
         usb=sdk4.types.Usb(
-            enabled=True,
+            enabled=False,
             type=sdk4.types.UsbType.NATIVE,
         ),
         memory_policy=sdk4.types.MemoryPolicy(
@@ -1444,23 +1444,27 @@ def test_add_nic(engine_api):
 
 
 @order_by(_TEST_LIST)
-def test_add_graphics_console(engine_api):
+def test_add_graphics_console(engine_api, ansible_host0_facts):
+    if ansible_host0_facts.get('ansible_distribution_major_version') == "9":
+        # trying to delete and re add VNC will add it back with QXL which doesnt supported on el9
+        # BZ 1976607
+        pytest.skip('skip test on el9')
     # remove VNC
     engine = engine_api.system_service()
     vm = test_utils.get_vm_service(engine, VM0_NAME)
     consoles_service = vm.graphics_consoles_service()
-    if len(consoles_service.list()) == 2:
+    consoles = consoles_service.list()
+    console = next((c for c in consoles if c.protocol == types.GraphicsType.VNC), None)
+    if console is not None:
         console = consoles_service.console_service('766e63')
         console.remove()
-        assert assert_utils.equals_within_short(lambda: len(consoles_service.list()), 1)
-
-    # and add it back
-    consoles_service.add(
-        sdk4.types.GraphicsConsole(
-            protocol=sdk4.types.GraphicsType.VNC,
+        assert assert_utils.equals_within_short(
+            lambda: types.GraphicsType.VNC in [t.protocol for t in consoles_service.list()], False
         )
+    consoles_service.add(console=types.GraphicsConsole(protocol=types.GraphicsType.VNC))
+    assert assert_utils.equals_within_short(
+        lambda: types.GraphicsType.VNC in [t.protocol for t in consoles_service.list()], True
     )
-    assert assert_utils.equals_within_short(lambda: len(consoles_service.list()), 2)
 
 
 @order_by(_TEST_LIST)


### PR DESCRIPTION
We need to create the VMs without QXL devices in order to run them on EL9.
The patch removes devices that use spice/qxl.