### PR TITLE
Enable keycloak for ost

### DIFF
--- a/ost_utils/pytest/fixtures/engine.py
+++ b/ost_utils/pytest/fixtures/engine.py
@@ -60,8 +60,9 @@ def engine_webadmin_url(engine_fqdn):
 
 @pytest.fixture(scope="session")
 def keycloak_enabled(ost_images_distro, suite):
-    # turn back on when engine starts using keycloak
-    return False
+    # internally bundled Keycloak authentication is by default (via engine-setup) enabled only for upstream (el8stream)
+    # downstream (rhel) still depends on legacy AAA. Keycloak authentication can still be enabled manually
+    return ost_images_distro != 'rhel8' and suite != 'he-basic-suite-master'
 
 
 @pytest.fixture(scope="session")

--- a/ost_utils/pytest/fixtures/engine.py
+++ b/ost_utils/pytest/fixtures/engine.py
@@ -62,7 +62,7 @@ def engine_webadmin_url(engine_fqdn):
 def keycloak_enabled(ost_images_distro, suite):
     # internally bundled Keycloak authentication is by default (via engine-setup) enabled only for upstream (el8stream)
     # downstream (rhel) still depends on legacy AAA. Keycloak authentication can still be enabled manually
-    return ost_images_distro != 'rhel8' and suite != 'he-basic-suite-master'
+    return ost_images_distro != 'rhel8'
 
 
 @pytest.fixture(scope="session")

--- a/ost_utils/pytest/fixtures/he.py
+++ b/ost_utils/pytest/fixtures/he.py
@@ -166,6 +166,11 @@ def he_engine_answer_file_openscap_profile_snippet(ansible_host0):
 
 
 @pytest.fixture(scope="session")
+def he_engine_answer_file_keycloak_snippet(keycloak_enabled):
+    return 'OVEHOSTED_CORE/enableKeycloak=bool:True\n' if keycloak_enabled else ''
+
+
+@pytest.fixture(scope="session")
 def he_engine_answer_file_contents(
     he_host_name,
     he_domain_name,
@@ -180,6 +185,7 @@ def he_engine_answer_file_contents(
     root_password,
     he_engine_answer_file_storage_snippet,
     he_engine_answer_file_openscap_profile_snippet,
+    he_engine_answer_file_keycloak_snippet,
 ):
     return (
         '[environment:init]\n'
@@ -216,6 +222,7 @@ def he_engine_answer_file_contents(
         f'{he_engine_answer_file_storage_snippet}'
         'OVEHOSTED_CORE/ansibleUserExtraVars=str:he_offline_deployment=true\n'
         f'{he_engine_answer_file_openscap_profile_snippet}'
+        f'{he_engine_answer_file_keycloak_snippet}'
     )
 
 


### PR DESCRIPTION
This patch re-enables keycloak support for both basic and he suites for non-rhel executions.
It's a merge of the following PRs:
- https://github.com/oVirt/ovirt-system-tests/pull/133
- https://github.com/oVirt/ovirt-system-tests/pull/124

Depends on: 
- https://github.com/oVirt/ovirt-engine/pull/295
- https://github.com/oVirt/ovirt-ansible-collection/pull/488
- https://github.com/oVirt/ovirt-hosted-engine-setup/pull/44