### PR TITLE
selenium: Use standalone nodes running one at a time

### DIFF
--- a/ost_utils/selenium/grid/__init__.py
+++ b/ost_utils/selenium/grid/__init__.py
@@ -1,0 +1,5 @@
+#
+# Copyright oVirt Authors
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+#

--- a/ost_utils/selenium/grid/browser.py
+++ b/ost_utils/selenium/grid/browser.py
@@ -1,0 +1,52 @@
+#
+# Copyright oVirt Authors
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+#
+
+import functools
+
+from selenium import webdriver
+
+
+BROWSER_PLATFORM = 'LINUX'
+CHROME_VERSION = 'latest'
+FIREFOX_VERSION = 'latest'
+
+
+@functools.cache
+def firefox_options():
+    options = webdriver.FirefoxOptions()
+    options.set_capability('platform', BROWSER_PLATFORM)
+    options.set_capability('version', FIREFOX_VERSION)
+    options.set_capability('browserName', 'firefox')
+    options.set_capability('acceptInsecureCerts', True)
+    # https://bugzilla.mozilla.org/show_bug.cgi?id=1538486
+    options.set_capability('moz:useNonSpecCompliantPointerOrigin', True)
+
+    options.set_preference('devtools.console.stdout.content', True)
+    options.set_preference("browser.download.folderList", 2)
+    options.set_preference("browser.download.dir", "/export")
+    options.set_preference("browser.helperApps.neverAsk.saveToDisk", "application/x-virt-viewer")
+    return options
+
+
+@functools.cache
+def chrome_options():
+    options = webdriver.ChromeOptions()
+    options.set_capability('platform', BROWSER_PLATFORM)
+    options.set_capability('version', CHROME_VERSION)
+    options.set_capability('acceptInsecureCerts', True)
+    options.set_capability(
+        'goog:loggingPrefs',
+        {
+            'browser': 'ALL',
+            'performance': 'ALL',
+        },
+    )
+
+    prefs = {'download.default_directory': '/export'}
+    options.add_experimental_option('prefs', prefs)
+    # note: response body is not logged
+    options.add_experimental_option('perfLoggingPrefs', {'enableNetwork': True, 'enablePage': True})
+    return options


### PR DESCRIPTION
In an attempt to limit the resources needed to run Selenium we're now using
the "standalone" images and running a single browser at a time.

[Related change](https://github.com/oVirt/ost-images/pull/53) on ost-images side.

Signed-off-by: Marcin Sobczyk <msobczyk@redhat.com>
Change-Id: Ic57391f70e22fb07bbbf441e7874fbf406d71232
