### PR TITLE
selenium: Use specific version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ ansible-runner
 pytest==6.2.2
 # basic suite deps
 requests
-selenium
+selenium==4.1.3
 # network suite deps
 # TODO Use pip version once released openstacksdk>=0.62.0
 git+https://github.com/openstack/openstacksdk.git@master


### PR DESCRIPTION
The newly released Selenium 4.1.5 version broke OST. Until we have a fix
let's use the older one.

Signed-off-by: Marcin Sobczyk <msobczyk@redhat.com>
