### PR TITLE
ost_utils: vmconsole - use default byte stream

### DIFF
--- a/ost_utils/vmconsole.py
+++ b/ost_utils/vmconsole.py
@@ -103,6 +103,7 @@ class VmSerialConsole(object):  # pylint: disable=too-many-instance-attributes
             signal.signal(signal.SIGALRM, self._read_alarm.handle)
             time.sleep(15)
             self._pre_login()
+            LOGGER.debug('vmconsole: logging in')
             self._read_until_prompt('login: ')
             self._write(f'{self._user}\n')
             self._read_until_prompt('Password: ')
@@ -149,7 +150,7 @@ class VmSerialConsole(object):  # pylint: disable=too-many-instance-attributes
                 self._write(entry)
                 res = self._read_until_bash_prompt()
                 res = res.replace(entry, '').rsplit(self._prompt)[0]
-                LOGGER.debug(f'vmconsole: shell {cmd} returned: {res}')
+                LOGGER.debug(f'vmconsole: command: [{cmd}] returned: [{res}]')
         return res
 
     def can_log_in(self, vm_id):
@@ -165,7 +166,7 @@ class VmSerialConsole(object):  # pylint: disable=too-many-instance-attributes
         return self._read_until_prompt(self._prompt)
 
     def _read_until_prompt(self, prompt):
-        LOGGER.debug(f'vmconsole: reading until {prompt}...')
+        LOGGER.debug(f'vmconsole: reading until [{prompt}]...')
         time.sleep(2)
         recv = ''
         try:

--- a/ost_utils/vmconsole.py
+++ b/ost_utils/vmconsole.py
@@ -132,7 +132,7 @@ class VmSerialConsole(object):  # pylint: disable=too-many-instance-attributes
 
     def add_static_ip(self, vm_id, ip, iface):
         ips = self.shell(vm_id, (Shell.ip_address_add(ip, iface), Shell.get_ips(iface)))
-        ip_version = ipaddress.ip_address(ip.split('/')[0]).version
+        ip_version = ipaddress.ip_interface(ip).version
         return Shell.next_ip(ips.splitlines(), ip_version)
 
     def get_ip(self, vm_id, iface, ip_version):

--- a/ost_utils/vmconsole.py
+++ b/ost_utils/vmconsole.py
@@ -153,8 +153,12 @@ class VmSerialConsole(object):  # pylint: disable=too-many-instance-attributes
         return res
 
     def can_log_in(self, vm_id):
-        with self.connect(vm_id) as console:
-            logged_in = console.logged_in
+        try:
+            with self.connect(vm_id) as console:
+                logged_in = console.logged_in
+        except BlockingIOError as e:
+            LOGGER.debug(f'vmconsole: could not log in: {e.args[0]}')
+            logged_in = False
         return logged_in
 
     @property

--- a/ost_utils/vmconsole.py
+++ b/ost_utils/vmconsole.py
@@ -39,7 +39,7 @@ class VmSerialConsole(object):  # pylint: disable=too-many-instance-attributes
         self._prompt = bash_prompt
         self._connected = False
         self._logged_in = False
-        self._read_alarm = BlockingIOAlarm('timed out waiting for read', 15)
+        self._read_alarm = BlockingIOAlarm('timed out waiting for read', 120)
 
     @contextlib.contextmanager
     def connect(self, vm_id):
@@ -56,7 +56,6 @@ class VmSerialConsole(object):  # pylint: disable=too-many-instance-attributes
 
     @contextlib.contextmanager
     def _connect(self, vm_id):
-        time.sleep(15)
         try:
             master, slave = pty.openpty()
             LOGGER.debug('vmconsole: opened pty')
@@ -100,7 +99,7 @@ class VmSerialConsole(object):  # pylint: disable=too-many-instance-attributes
     def _login(self):
         try:
             signal.signal(signal.SIGALRM, self._read_alarm.handle)
-            time.sleep(15)
+            time.sleep(30)
             self._pre_login()
             LOGGER.debug('vmconsole: logging in')
             self._read_until_prompt('login: ')
@@ -122,7 +121,7 @@ class VmSerialConsole(object):  # pylint: disable=too-many-instance-attributes
             byte = self._read()
             if byte in (b'\n', b'\r') or len(byte.strip()) != 0:
                 break
-            time.sleep(2)
+            time.sleep(10)
 
     def _logout(self):
         LOGGER.debug('vmconsole: logging out')
@@ -170,7 +169,7 @@ class VmSerialConsole(object):  # pylint: disable=too-many-instance-attributes
 
     def _read_until_prompt(self, prompt):
         LOGGER.debug(f'vmconsole: reading until [{prompt}]...')
-        time.sleep(2)
+        time.sleep(5)
         _bytes = b''
         try:
             encoded_prompt = prompt.encode()
@@ -187,7 +186,6 @@ class VmSerialConsole(object):  # pylint: disable=too-many-instance-attributes
         return byte
 
     def _write(self, entry):
-        time.sleep(2)
         LOGGER.debug(f'vmconsole: writing [{entry}]')
         self._writer.write(entry)
         self._writer.flush()


### PR DESCRIPTION
Align with PR#135 [1]:

By default 'Popen' processes's stdout is opened as a byte stream.
Passing the 'universal_newlines=True' argument makes the stream
automatically decoded from UTF-8.

Since we're reading the output char by char, multibyte UTF-8 characters
can break the stream with i.e.:

E UnicodeDecodeError: 'utf-8' codec can't decode byte 0xda ...
invalid continuation byte

Let's change the output to have a form of bytes and use bytes in
comparisons too.

[1] https://github.com/oVirt/ovirt-system-tests/pull/135

Change-Id: I799faaa6617b7a1f48ce9175509eef1d7e62c4de

Signed-off-by: Eitan Raviv <eraviv@redhat.com>
Change-Id: Ic550276233f6e1908c67d4c8a3cd9d7a05a5cd4a