### PR TITLE
el9stream: Reboot all hosts

### DIFF
--- a/ost_utils/pytest/fixtures/defaults.py
+++ b/ost_utils/pytest/fixtures/defaults.py
@@ -28,8 +28,11 @@ def hostnames_to_add(hosts_hostnames):
 
 
 @pytest.fixture(scope="session")
-def hostnames_to_reboot(hosts_hostnames):
-    return hosts_hostnames[:1]
+def hostnames_to_reboot(hosts_hostnames, ost_images_distro):
+    # for el8stream we reboot only one of the hosts to make the run faster,
+    # but on el9stream we need to reboot all of them to apply the monolithic
+    # libvirt preset
+    return hosts_hostnames if ost_images_distro == "el9stream" else hosts_hostnames[:1]
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
On el9stream hosts we configure libvirt to use the monolithic daemon
during host deployment [1]. Until now we used to reboot only one of the
hosts in a basic suite run to make it faster, but that libvirt change
requires all hosts to be rebooted.

[1] https://github.com/oVirt/ovirt-engine/pull/80

Signed-off-by: Marcin Sobczyk <msobczyk@redhat.com>
