### PR TITLE
readme: username is admin@ovirt if keycloak is enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Once you've located the engine VM's IP, add it to `/etc/hosts`. You have to use 
 Now, log in to the web-UI at:
 
 * URL: `https://engine/ovirt-engine/webadmin/`
-* Username: `admin`
+* Username: `admin` or `admin@ovirt` if keycloak is enabled
 * Password: `123456`
 * Profile: `internal`
 

--- a/basic-suite-master/test-scenarios/test_100_basic_ui_sanity.py
+++ b/basic-suite-master/test-scenarios/test_100_basic_ui_sanity.py
@@ -590,5 +590,4 @@ def test_grafana(
 
     grafana.open_dashboard('oVirt Inventory Dashboards', '02 Hosts Inventory Dashboard')
     assert not grafana.is_error_visible()
-
     save_screenshot('grafana-dashboard-2')


### PR DESCRIPTION
When keycloak is enabled to web-UI username is admin@ovirt, instead of admin.
see https://github.com/oVirt/ovirt-system-tests/blob/88ac8f4bf969fed610edb8c2e3e47af38cbdea31/ost_utils/pytest/fixtures/engine.py#L69