### PR TITLE
engine deploy: downgrade ovn - temp workaround

### DIFF
--- a/common/deploy-scripts/setup_engine.sh
+++ b/common/deploy-scripts/setup_engine.sh
@@ -34,3 +34,15 @@ cp /usr/share/doc/ovirt-engine/mibs/* /usr/share/snmp/mibs
 systemctl start snmptrapd
 systemctl enable snmptrapd
 
+# TODO: work around for https://bugzilla.redhat.com/2091565 - Downgrade OVN to 21.12.0-46 to match version on RHEVH
+rpm -q rhvm && {
+  cat << EOF > /etc/yum.repos.d/fast_datapath.repo
+[fast-datapath]
+name=fast-datapath
+baseurl=http://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel8/x86_64/fast-datapath/os
+gpgcheck=0
+enabled=1
+EOF
+  dnf downgrade -y --repo fast-datapath ovn-2021-central-21.12.0-46.el8fdp
+}
+


### PR DESCRIPTION
Downgrade OVN to 21.12.0-46 on the engine machine so it matches the
latest available version for RHVH.

Change-Id: I6bc99e9d5aa0beb19a70d8f124407e0f7c7fffe4
Bug-Url: https://bugzilla.redhat.com/2091565
Signed-off-by: Eitan Raviv <eraviv@redhat.com>