### PR TITLE
ost_utils: vmconsole - ignore decode errors

### DIFF
--- a/ost_utils/vmconsole.py
+++ b/ost_utils/vmconsole.py
@@ -177,7 +177,7 @@ class VmSerialConsole(object):  # pylint: disable=too-many-instance-attributes
                 _bytes += self._read()
         finally:
             LOGGER.debug(f'vmconsole: _read_until_prompt: read so far: [{repr(_bytes)}]')
-        return _bytes.decode().replace('\r', '')
+        return _bytes.decode(errors='ignore').replace('\r', '')
 
     def _read(self):
         signal.alarm(self._read_alarm.seconds)


### PR DESCRIPTION
When a VM misbehaves, e.g. very slow to respond, it sometimes sends
non-decodable bytes on the vmconsole connection stream. These bytes can
be ignored while waiting for the expected response.

Change-Id: Id4027103d609f42642e744387c80b3dccbd0ca43

Signed-off-by: Eitan Raviv <eraviv@redhat.com>