### PR TITLE
network: ensure multiple hot plug\unplug vnics is safe

### DIFF
--- a/network-suite-master/ovirtlib/netlib.py
+++ b/network-suite-master/ovirtlib/netlib.py
@@ -205,6 +205,10 @@ class Vnic(SDKSubEntity):
         return self.get_sdk_type().name
 
     @property
+    def plugged(self):
+        return self.get_sdk_type().plugged
+
+    @property
     def linked(self):
         return self.get_sdk_type().linked
 


### PR DESCRIPTION
Multiple hot plug and hot unplug rounds of several vNICs in fast
succession should be safe and not cause any vNIC to get stuck in the
wrong status.

Bug-Url: https://bugzilla.redhat.com/2084530
Change-Id: I404835db89a6bd5048209e6d14ccb8fc3172bc8f

Signed-off-by: Eitan Raviv <eraviv@redhat.com>
Change-Id: I0d39c2f9cf716d2a6bde436bf3888f4caa18416f