### PR TITLE
Disable keycloak if it's not enabled

### DIFF
--- a/ost_utils/pytest/fixtures/he.py
+++ b/ost_utils/pytest/fixtures/he.py
@@ -167,7 +167,8 @@ def he_engine_answer_file_openscap_profile_snippet(ansible_host0):
 
 @pytest.fixture(scope="session")
 def he_engine_answer_file_keycloak_snippet(keycloak_enabled):
-    return 'OVEHOSTED_CORE/enableKeycloak=bool:True\n' if keycloak_enabled else ''
+    val = 'True' if keycloak_enabled else 'False'
+    return f'OVEHOSTED_CORE/enableKeycloak=bool:{val}\n'
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
By passing 'None', we let stuff rely on defaults. Better be explicit.

Change-Id: I03fc6e39e094dc73a348e581c59d87e18bf18ee5
Signed-off-by: Yedidyah Bar David <didi@redhat.com>