### PR TITLE
el9: skip 389-ds configuration

### DIFF
--- a/common/deploy-scripts/setup_storage.sh
+++ b/common/deploy-scripts/setup_storage.sh
@@ -243,7 +243,8 @@ main() {
     activate_nfs
     setup_lvm_filter
     setup_iscsi
-    setup_389ds
+    # TODO el9 doesn't have 389-ds (LDAP) configuration yet
+    [ "$(. /etc/os-release; echo ${VERSION_ID})" != "9" ] && setup_389ds
     coredump_kill
 
     fstrim -va


### PR DESCRIPTION
we do not have up to date LDAP configuration, legacy tooling has been
dropped on EL9 so we are skipping it for now, we anyway do not have
el9-based ovirt-engine yet
