### PR TITLE
Change logout from user portal

### DIFF
--- a/basic-suite-master/test-scenarios/test_100_basic_ui_sanity.py
+++ b/basic-suite-master/test-scenarios/test_100_basic_ui_sanity.py
@@ -535,6 +535,7 @@ def test_userportal(
     nonadmin_password,
     user_login,
     engine_webadmin_url,
+    save_screenshot,
 ):
     welcome_screen = WelcomeScreen(ovirt_driver)
     welcome_screen.wait_for_displayed()
@@ -549,7 +550,10 @@ def test_userportal(
     assert assert_utils.equals_within_short(vm_portal.get_vm_count, 1)
     vm0_status = vm_portal.get_vm_status('vm0')
     assert vm0_status == 'Powering up' or vm0_status == 'Running'
+    save_screenshot('userportal')
+
     vm_portal.logout()
+    save_screenshot('userportal-logout')
 
     # navigate directly to welcome page to prevent problems with redirecting to login page instead of welcome page
     ovirt_driver.driver.get(engine_webadmin_url)

--- a/ost_utils/selenium/page_objects/VmPortal.py
+++ b/ost_utils/selenium/page_objects/VmPortal.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
 from selenium.webdriver.common.by import By
+from selenium.webdriver.common.action_chains import ActionChains
 from .Displayable import Displayable
 
 
@@ -28,4 +29,9 @@ class VmPortal(Displayable):
 
     def logout(self):
         self.ovirt_driver.xpath_wait_and_click('User dropdown menu', '//*[@id="usermenu-user"]')
-        self.ovirt_driver.xpath_wait_and_click('Logout menu', '//*[@id="usermenu-logout"]')
+        self.ovirt_driver.wait_until('Logout menu is present', self.ovirt_driver.is_id_present, 'usermenu-logout')
+
+        logout_menu = self.ovirt_driver.driver.find_element(By.XPATH, '//*[@id="usermenu-logout"]')
+        ActionChains(self.ovirt_driver.driver).move_to_element(logout_menu).click(logout_menu).perform()
+
+        self.ovirt_driver.wait_while('Vm portal still displayed', self.is_displayed)


### PR DESCRIPTION
The tests started to fail on logout due to the tooltip being displayed over menu item. This re-implementation should fix that.