### PR TITLE
Check VM Portal status based on presence of Refresh button

### DIFF
--- a/ost_utils/selenium/page_objects/VmPortal.py
+++ b/ost_utils/selenium/page_objects/VmPortal.py
@@ -11,9 +11,7 @@ class VmPortal(Displayable):
         super(VmPortal, self).__init__(ovirt_driver)
 
     def is_displayed(self):
-        return self.ovirt_driver.is_id_present(
-            'page-router-render-component'
-        ) and not self.ovirt_driver.is_class_name_present('spinner')
+        return self.ovirt_driver.is_id_present('pageheader-refresh')
 
     def get_displayable_name(self):
         return 'VM Portal'


### PR DESCRIPTION
After migrating VM Portal to PatternFly4 the CSS class used by the
spinner component has changed to "pf-c-spinner".

The new class should be checked together with the old class to ensure
smooth transition from PF3 to PF4.
