### PR TITLE
basic: enable graphics test on el9

### DIFF
--- a/basic-suite-master/test-scenarios/test_002_bootstrap.py
+++ b/basic-suite-master/test-scenarios/test_002_bootstrap.py
@@ -1443,10 +1443,6 @@ def test_add_nic(engine_api):
 
 @order_by(_TEST_LIST)
 def test_add_graphics_console(engine_api, ansible_host0_facts):
-    if ansible_host0_facts.get('ansible_distribution_major_version') == "9":
-        # trying to delete and re add VNC will add it back with QXL which doesnt supported on el9
-        # BZ 1976607
-        pytest.skip('skip test on el9')
     # remove VNC
     engine = engine_api.system_service()
     vm = test_utils.get_vm_service(engine, VM0_NAME)


### PR DESCRIPTION
With https://github.com/oVirt/ovirt-engine/pull/75 we no longer need to
skip this test on el9, VNC graphics is selected by default and allows
vm0 to run later on
