### PR TITLE
he: Run most tests under global maintenance

### DIFF
--- a/he-basic-suite-master/test-scenarios/test_001_he_deploy.py
+++ b/he-basic-suite-master/test-scenarios/test_001_he_deploy.py
@@ -8,6 +8,7 @@ import os
 
 import pytest
 
+from ost_utils import he_utils
 from ost_utils.deployment_utils import package_mgmt
 
 
@@ -78,6 +79,16 @@ def test_he_deploy(
     ansible_host0.shell('/root/setup_first_he_host.sh ' f'{he_host_name} ' f'{he_mac_address} ' f'{engine_ip}')
 
     ansible_storage.shell('fstrim -va')
+
+
+def test_set_global_maintenance(ansible_host0):
+    logging.info('Waiting For System Stability...')
+    he_utils.wait_until_engine_vm_is_not_migrating(ansible_host0)
+
+    he_utils.set_and_test_global_maintenance_mode(ansible_host0, True)
+
+    assert assert_utils.true_within_short(lambda: he_utils.all_hosts_state_global_maintenance(ansible_host0))
+    logging.info('Global maintenance state set on all hosts')
 
 
 def test_install_sar_collection(root_dir, ansible_engine):

--- a/he-basic-suite-master/test-scenarios/test_001_he_deploy.py
+++ b/he-basic-suite-master/test-scenarios/test_001_he_deploy.py
@@ -4,10 +4,12 @@
 #
 #
 
+import logging
 import os
 
 import pytest
 
+from ost_utils import assert_utils
 from ost_utils import he_utils
 from ost_utils.deployment_utils import package_mgmt
 

--- a/he-basic-suite-master/test-scenarios/test_008_restart_he_vm.py
+++ b/he-basic-suite-master/test-scenarios/test_008_restart_he_vm.py
@@ -14,16 +14,6 @@ from ost_utils import constants
 from ost_utils.ansible import AnsibleExecutionError
 
 
-def test_set_global_maintenance(ansible_host0):
-    logging.info('Waiting For System Stability...')
-    he_utils.wait_until_engine_vm_is_not_migrating(ansible_host0)
-
-    he_utils.set_and_test_global_maintenance_mode(ansible_host0, True)
-
-    assert assert_utils.true_within_short(lambda: he_utils.all_hosts_state_global_maintenance(ansible_host0))
-    logging.info('Global maintenance state set on all hosts')
-
-
 def test_restart_he_vm(ansible_by_hostname, ansible_host0):
     host_name = he_utils.host_name_running_he_vm(ansible_host0)
     ansible_host = ansible_by_hostname(host_name)


### PR DESCRIPTION
Move test_set_global_maintenance to test_001, so that HE HA does not
interfere with other OST stuff. In particular, running OpenSCAP reports
on the hosts caused high CPU and memory load, which caused HA to stop
the engine VM.

Change-Id: Ib7cb415f003ac0b630f4f50e3dc54c568b2c296a
Signed-off-by: Yedidyah Bar David <didi@redhat.com>