### PR TITLE
ost.sh: Add fetch-artifacts command

### DIFF
--- a/ansible-suite-master/test-scenarios/conftest.py
+++ b/ansible-suite-master/test-scenarios/conftest.py
@@ -7,9 +7,7 @@ import pytest
 
 from ost_utils.pytest.fixtures.ansible import *
 
-from ost_utils.pytest.fixtures.artifacts import artifacts
 from ost_utils.pytest.fixtures.artifacts import artifacts_dir
-from ost_utils.pytest.fixtures.artifacts import artifact_list
 from ost_utils.pytest.fixtures.artifacts import collect_artifacts
 from ost_utils.pytest.fixtures.artifacts import dump_dhcp_leases
 from ost_utils.pytest.fixtures.artifacts import generate_sar_stat_plots

--- a/basic-suite-master/test-scenarios/conftest.py
+++ b/basic-suite-master/test-scenarios/conftest.py
@@ -24,9 +24,7 @@ from ost_utils.pytest.fixtures.ansible import ansible_inventory
 from ost_utils.pytest.fixtures.ansible import ansible_storage
 from ost_utils.pytest.fixtures.ansible import ansible_storage_facts
 
-from ost_utils.pytest.fixtures.artifacts import artifacts
 from ost_utils.pytest.fixtures.artifacts import artifacts_dir
-from ost_utils.pytest.fixtures.artifacts import artifact_list
 from ost_utils.pytest.fixtures.artifacts import collect_artifacts
 from ost_utils.pytest.fixtures.artifacts import collect_vdsm_coverage_artifacts
 from ost_utils.pytest.fixtures.artifacts import dump_dhcp_leases

--- a/common/scripts/fetch_artifacts.yml
+++ b/common/scripts/fetch_artifacts.yml
@@ -1,0 +1,58 @@
+#!/usr/bin/ansible-playbook
+
+- hosts: all
+
+  vars:
+    archive_name: artifacts.tar.gz
+    remote_archive_path: "/var/tmp/{{ archive_name }}"
+    artifact_list:
+      - /etc/dnf
+      - /etc/firewalld
+      - /etc/grafana
+      - /etc/httpd/conf
+      - /etc/httpd/conf.d
+      - /etc/httpd/conf.modules.d
+      - /etc/ovirt-engine
+      - /etc/ovirt-engine-dwh
+      - /etc/ovirt-engine-metrics
+      - /etc/ovirt-engine-setup.conf.d
+      - /etc/ovirt-engine-setup.env.d
+      - /etc/ovirt-host-deploy.conf.d
+      - /etc/ovirt-imageio-proxy
+      - /etc/ovirt-provider-ovn
+      - /etc/ovirt-vmconsole
+      - /etc/ovirt-web-ui
+      - /etc/resolv.conf
+      - /etc/sysconfig
+      - /etc/yum
+      - /etc/yum.repos.d
+      - /root
+      - /tmp/dnf_yum.conf
+      - /var/cache/ovirt-engine
+      - /var/lib/ovirt-engine/setup/answers
+      - /var/lib/ovirt-engine/ansible-runner
+      - /var/lib/pgsql/initdb_postgresql.log
+      - /var/lib/pgsql/data/log
+      - /var/log
+    ost_repo_root: "{{ lookup('env', 'OST_REPO_ROOT') }}"
+
+  tasks:
+    - name: Get the journal right before collecting
+      ansible.builtin.shell: journalctl -a --no-pager -o short-iso-precise > /var/log/journalctl.log
+
+    - name: Archive artifacts
+      community.general.archive:
+        path: "{{ artifact_list }}"
+        dest: "{{ remote_archive_path }}"
+
+    - name: Fetch archived artifacts
+      ansible.builtin.fetch:
+        src: "{{ remote_archive_path }}"
+        dest: "{{ ost_repo_root }}/exported-artifacts/test_logs/{{ inventory_hostname }}/{{ archive_name }}"
+        flat: yes
+
+    - name: Extract the artifacts
+      local_action: ansible.builtin.command tar -xf {{ ost_repo_root }}/exported-artifacts/test_logs/{{ inventory_hostname }}/{{ archive_name }} -C {{ ost_repo_root }}/exported-artifacts/test_logs/{{ inventory_hostname }}
+
+    - name: Clean up the archives
+      local_action: ansible.builtin.command rm {{ ost_repo_root }}/exported-artifacts/test_logs/{{ inventory_hostname }}/{{ archive_name }}

--- a/he-basic-suite-master/test-scenarios/test_001_he_deploy.py
+++ b/he-basic-suite-master/test-scenarios/test_001_he_deploy.py
@@ -113,10 +113,6 @@ def test_install_sar_collection(root_dir, ansible_engine):
     )
 
 
-def test_add_engine_to_artifacts(artifacts, he_host_name, artifact_list):
-    artifacts[he_host_name] = artifact_list
-
-
 def test_check_installed_packages(request, ansible_all):
     if request.config.getoption('--skip-custom-repos-check'):
         pytest.skip('the check was disabled by the run argument')

--- a/lagofy.sh
+++ b/lagofy.sh
@@ -314,7 +314,7 @@ ost_console() {
 
 ost_fetch_artifacts() {
     _deployment_exists
-    ansible-playbook -i deployment/ansible_inventory -u root --ssh-common-args '-o StrictHostKeyChecking=no' common/scripts/fetch_artifacts.yml >/dev/null || {
+    ansible-playbook -i $OST_DEPLOYMENT/ansible_inventory -u root --ssh-common-args '-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null' common/scripts/fetch_artifacts.yml >/dev/null || {
         echo "ansible playbook failed"
         return 9
     };

--- a/lagofy.sh
+++ b/lagofy.sh
@@ -312,6 +312,14 @@ ost_console() {
     fi
 }
 
+ost_fetch_artifacts() {
+    _deployment_exists
+    ansible-playbook -i deployment/ansible_inventory -u root --ssh-common-args '-o StrictHostKeyChecking=no' common/scripts/fetch_artifacts.yml >/dev/null || {
+        echo "ansible playbook failed"
+        return 9
+    };
+}
+
 # check dependencies
 ost_check_dependencies() {
     ${PYTHON} -V 2>/dev/null | grep -q ^Python || { echo "$PYTHON is not installed"; return 2; }

--- a/network-suite-master/test-scenarios/conftest.py
+++ b/network-suite-master/test-scenarios/conftest.py
@@ -57,9 +57,7 @@ from ost_utils.pytest.fixtures.ansible import ansible_hosts
 from ost_utils.pytest.fixtures.ansible import ansible_storage_facts
 from ost_utils.pytest.fixtures.ansible import ansible_inventory
 from ost_utils.pytest.fixtures.ansible import ansible_storage
-from ost_utils.pytest.fixtures.artifacts import artifacts
 from ost_utils.pytest.fixtures.artifacts import artifacts_dir
-from ost_utils.pytest.fixtures.artifacts import artifact_list
 from ost_utils.pytest.fixtures.artifacts import collect_artifacts
 from ost_utils.pytest.fixtures.artifacts import dump_dhcp_leases
 from ost_utils.pytest.fixtures.artifacts import generate_sar_stat_plots

--- a/ost.sh
+++ b/ost.sh
@@ -14,6 +14,8 @@ shell <host> [command ...]
     opens ssh connection
 console <host>
     opens virsh console
+fetch-artifacts
+    fetches artifacts from all hosts
 destroy
     stop and remove the running environment
 "
@@ -40,6 +42,9 @@ case "$cmd" in
   console)
     host=$1; shift;
     ost_console $host $@
+    ;;
+  fetch-artifacts)
+    ost_fetch_artifacts
     ;;
   shell)
     host=$1; shift;

--- a/ost_utils/pytest/fixtures/artifacts.py
+++ b/ost_utils/pytest/fixtures/artifacts.py
@@ -9,6 +9,7 @@ import logging
 import os
 
 import pytest
+import yaml
 
 from ost_utils import coverage
 from ost_utils import utils
@@ -25,36 +26,9 @@ def artifacts_dir():
 
 @pytest.fixture(scope="session")
 def artifact_list():
-    return [
-        '/etc/dnf',
-        '/etc/firewalld',
-        '/etc/grafana',
-        '/etc/httpd/conf',
-        '/etc/httpd/conf.d',
-        '/etc/httpd/conf.modules.d',
-        '/etc/ovirt-engine',
-        '/etc/ovirt-engine-dwh',
-        '/etc/ovirt-engine-metrics',
-        '/etc/ovirt-engine-setup.conf.d',
-        '/etc/ovirt-engine-setup.env.d',
-        '/etc/ovirt-host-deploy.conf.d',
-        '/etc/ovirt-imageio-proxy',
-        '/etc/ovirt-provider-ovn',
-        '/etc/ovirt-vmconsole',
-        '/etc/ovirt-web-ui',
-        '/etc/resolv.conf',
-        '/etc/sysconfig',
-        '/etc/yum',
-        '/etc/yum.repos.d',
-        '/root',
-        '/tmp/dnf_yum.conf',
-        '/var/cache/ovirt-engine',
-        '/var/lib/ovirt-engine/setup/answers',
-        '/var/lib/ovirt-engine/ansible-runner',
-        '/var/lib/pgsql/initdb_postgresql.log',
-        '/var/lib/pgsql/data/log',
-        '/var/log',
-    ]
+    with open(os.path.join(os.environ["OST_REPO_ROOT"], "common", "scripts", "fetch_artifacts.yml"), "r") as f:
+        playbook = yaml.safe_load(f)
+    return playbook[0]['vars']['artifact_list']
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
While fixtures for collecting artifacts are very handy and work
really well, it's useful to have a tool for adhoc artifact
downloading to cover cases of OST runs that are hanging forever
in some place.