### PR TITLE
Test that notifier works after restart

### DIFF
--- a/common/deploy-scripts/setup_engine.sh
+++ b/common/deploy-scripts/setup_engine.sh
@@ -69,7 +69,7 @@ cp /usr/share/doc/ovirt-engine/mibs/* /usr/share/snmp/mibs
 
 # We have to set DAYS_TO_SEND_ON_STARTUP to 1 because its default value is 0
 # it means that it will not send any old events, a race between the service start and
-# the new tag added above will cause that this event will not processed.
+# the new tag added above will cause that this event is not processed.
 echo "DAYS_TO_SEND_ON_STARTUP=1" >  /etc/ovirt-engine/notifier/notifier.conf.d/30-ovirt-engine-notifier.conf
 
 

--- a/common/deploy-scripts/setup_engine.sh
+++ b/common/deploy-scripts/setup_engine.sh
@@ -67,6 +67,12 @@ EOF
 
 cp /usr/share/doc/ovirt-engine/mibs/* /usr/share/snmp/mibs
 
+# We have to set DAYS_TO_SEND_ON_STARTUP to 1 because its default value is 0
+# it means that it will not send any old events, a race between the service start and
+# the new tag added above will cause that this event will not processed.
+echo "DAYS_TO_SEND_ON_STARTUP=1" >  /etc/ovirt-engine/notifier/notifier.conf.d/30-ovirt-engine-notifier.conf
+
+
 systemctl start snmpd
 systemctl start snmptrapd
 # new user created in net-snmp/snmpd*.conf are available only after services are restarted


### PR DESCRIPTION
Verify that snmp traps works after restart

This patch verifies that SNMP traps are still working after
ovirt-engine-notifier and snmptrapd services are restarted.

First the services are restarted, then a new tag "notifiertag" is added to
the system, finally we check that a trap generated on the new tag created is
logged to snmptrapd.log

We have to set the configuration value DAYS_TO_SEND_ON_STARTUP to 1 in engine setup
because its default value is 0, it means that it will not send any old events,
a race between the service start and the new "notifiertag" tag will cause that this
event will not be processed.

