### PR TITLE
he: increase host-0 memory 1GB

### DIFF
--- a/common/init-configs/1_hosted_engine_2_hosts.json
+++ b/common/init-configs/1_hosted_engine_2_hosts.json
@@ -51,7 +51,7 @@
   },
   "host-0": {
     "template": "common/libvirt-templates/vm_template",
-    "memory": "5744",
+    "memory": "6768",
     "deploy-scripts": [
       "common/deploy-scripts/setup_host.sh"
     ],


### PR DESCRIPTION
sometimes HE VM has troubles booting and it seeems to be related to
memory fragmentation or some other problem during initial allocation.
Let's try with 1GB more on host-0 only, as once it boots there is no
need for so much memory
