### PR TITLE
metrics: Use daemonic threads to run the playbooks

### DIFF
--- a/basic-suite-master/test-scenarios/test_003_00_metrics_bootstrap.py
+++ b/basic-suite-master/test-scenarios/test_003_00_metrics_bootstrap.py
@@ -99,6 +99,7 @@ def test_metrics_and_log_collector(setup_log_collector, suite_dir, ansible_engin
                     functools.partial(configure_metrics, suite_dir, ansible_engine, ansible_hosts),
                     functools.partial(run_log_collector, ansible_engine),
                 ],
+                daemon=True,
             )
             vt.start_all()
             vt.join_all(timeout=120)

--- a/ost_utils/utils.py
+++ b/ost_utils/utils.py
@@ -63,15 +63,16 @@ class TimeoutException(Exception):
 
 
 class VectorThread:
-    def __init__(self, targets):
+    def __init__(self, targets, daemon=False):
         self.targets = targets
         self.queues = [queue.Queue()] * len(targets)
         self.thread_handles = []
         self.results = []
+        self.daemon = daemon
 
     def start_all(self):
         for target, q in zip(self.targets, self.queues):
-            t = threading.Thread(target=_ret_via_queue, args=(target, q))
+            t = threading.Thread(target=_ret_via_queue, args=(target, q), daemon=self.daemon)
             self.thread_handles.append(t)
             t.start()
 


### PR DESCRIPTION
The PR is a continuation of the effort to mitigate problems with metrics
configuration playbook hanging forever. The first part was here [1].

Now we don't hang on the playbook execution, but we do hang at the end
of the pytest session - Python waits on all the threads to be done.
That rule doesn't apply to daemonic threads, so let's use them in this
case.

[1] https://github.com/oVirt/ovirt-system-tests/pull/188

Signed-off-by: Marcin Sobczyk <msobczyk@redhat.com>
