### PR TITLE
coverage: Make OST coverage optional

### DIFF
--- a/ost.sh
+++ b/ost.sh
@@ -4,7 +4,7 @@ help() {
 echo "
 $0 command [arguments]
 
-run [-4|-6] <suite> <distro> [<pytest args>...]
+run [-4|-6] [--ost-coverage] <suite> <distro> [<pytest args>...]
     initializes the workspace with preinstalled distro ost-images, launches VMs and runs the whole suite
     add extra repos with --custom-repo=url
     skip check that extra repo is actually used with --skip-custom-repos-check
@@ -28,10 +28,11 @@ cmd=$1; shift
 case "$cmd" in
   run)
     [[ "$1" =~ ^-4$|^-6$ ]] && { ipv=$1; shift; }
+    [[ "$1" == "--ost-coverage" ]] && { ost_coverage_flag=$1; shift; }
     suite=$1; shift
     distro=$1; shift
     ost_init $ipv $suite $distro || exit 1
-    ost_run_tests $@ || exit 1
+    ost_run_tests $ost_coverage_flag $@ || exit 1
     ;;
   status)
     ost_status


### PR DESCRIPTION
OST coverage is really helpful, but we should have it under a flag.

This PR introduces an '--ost-coverage' flag that can be passed like this:

 ./ost.sh run --ost-coverage network-suite-master el8stream

or used directly in lagofied env like this:

 ost_run_tests --ost-coverage

Signed-off-by: Marcin Sobczyk <msobczyk@redhat.com>
Change-Id: Iaf8210f3eba54b2d40034d89ff345e5e88f6d20d
