### PR TITLE
vdsm: Log storage entries with 'DEBUG' level

### DIFF
--- a/basic-suite-master/test-scenarios/test_002_bootstrap.py
+++ b/basic-suite-master/test-scenarios/test_002_bootstrap.py
@@ -385,6 +385,7 @@ def test_complete_hosts_setup(ansible_hosts):
 
     loggers = (
         ('root', 'root'),
+        ('storage', 'storage'),
         ('vds', 'vds'),
         ('virt', 'virt'),
         ('schema_inconsistency', 'schema.inconsistency'),


### PR DESCRIPTION
We're running into a problem currently where vdsm becomes completely
unresponsive probably after trying to reattach a storage domain. To have
more insights on what's going on we're making the 'storage' loggers log
with 'DEBUG' level.

Signed-off-by: Marcin Sobczyk <msobczyk@redhat.com>
