### PR TITLE
vm-template: Improve disk driver configuration

### DIFF
--- a/common/libvirt-templates/vm_template
+++ b/common/libvirt-templates/vm_template
@@ -38,7 +38,7 @@
   <devices>
     <emulator>/usr/libexec/qemu-kvm</emulator>
     <disk type='file' device='disk'>
-      <driver name='qemu' type='qcow2'/>
+      <driver name='qemu' type='qcow2' cache='none' io='native' discard='unmap' iothread='1'/>
       <source file='@OST_ROOTDISK@'/>
       <target dev='vda' bus='virtio'/>
       <boot order='1'/>


### PR DESCRIPTION
- Use cache='none' to avoid double caches on host and gust. With
  cache='none' writes bypass the host page cache, and less memory is
  used on the host for caching. This also enabled usage of io='native'.

- Use io='native' which is the recommended configuration. With this I/O
  is submitted using single thread using libaio. This is usually faster
  than io='threads', and more important for OST, it uses one thread
  instead of multiple threads on qemu side, which keep the load on the
  host lower. This can improve reliability and performance when running
  many vms with few CPUs (as seem to happen in OST).

- Use discard='unmap' so discard requests punch holes in the images.
  I'm not sure it is useful for qcow2 images but it is a good default,
  in particular for developers running OST locally on small disks.

- Use iothread='1' - Enable I/O thread for the disk. We configured one
  I/O thread but it was not used. This can improve performance and
  reduce the chance of of blocking qemu when handling I/O on the event
  loop thread.
