### PR TITLE
engine: Restore original 'ovirt-engine.xml.in' after engine setup

### DIFF
--- a/basic-suite-master/test-scenarios/test_001_initialize_engine.py
+++ b/basic-suite-master/test-scenarios/test_001_initialize_engine.py
@@ -6,8 +6,30 @@
 from __future__ import absolute_import
 
 import os
+import os.path
+
+import pytest
 
 from ost_utils.ansible.collection import engine_setup
+
+
+@pytest.fixture(scope="function")
+def xml_with_debug_enabled(ansible_engine):
+    xml_path = '/usr/share/ovirt-engine/services/ovirt-engine/ovirt-engine.xml.in'
+    xml_tmp_path = f'/tmp/{os.path.basename(xml_path)}'
+    if os.environ.get('ENABLE_DEBUG_LOGGING'):
+        ansible_engine.shell(f'mv {xml_path} {xml_tmp_path} && cp {xml_tmp_path} {xml_path}')
+        ansible_engine.shell(
+            'sed -i '
+            '-e "/.*logger category=\\"org.ovirt\\"/{ n; s/INFO/DEBUG/ }" '
+            '-e "/.*logger category=\\"org.ovirt.engine.core.bll\\"/{ n; s/INFO/DEBUG/ }" '  # noqa: E501
+            '-e "/.*logger category=\\"org.keycloak\\"/{ n; s/INFO/DEBUG/ }" '
+            '-e "/.*<root-logger>/{ n; s/INFO/DEBUG/ }" '
+            f'{xml_path}'
+        )
+    yield
+    if os.environ.get('ENABLE_DEBUG_LOGGING'):
+        ansible_engine.shell(f'mv {xml_tmp_path} {xml_path}')
 
 
 def test_initialize_engine(
@@ -17,17 +39,8 @@ def test_initialize_engine(
     engine_hostname,
     ssh_key_file,
     engine_answer_file_path,
+    xml_with_debug_enabled,
 ):
-    if os.environ.get('ENABLE_DEBUG_LOGGING'):
-        ansible_engine.shell(
-            'sed -i '
-            '-e "/.*logger category=\\"org.ovirt\\"/{ n; s/INFO/DEBUG/ }" '
-            '-e "/.*logger category=\\"org.ovirt.engine.core.bll\\"/{ n; s/INFO/DEBUG/ }" '  # noqa: E501
-            '-e "/.*logger category=\\"org.keycloak\\"/{ n; s/INFO/DEBUG/ }" '
-            '-e "/.*<root-logger>/{ n; s/INFO/DEBUG/ }" '
-            '/usr/share/ovirt-engine/services/ovirt-engine/ovirt-engine.xml.in'
-        )
-
     engine_setup(
         ansible_engine,
         ansible_inventory,


### PR DESCRIPTION
PCI DSS openscap profile verifies checksums of files coming from RPMs.
Modified files are reported as a problem. We change the contents
of 'ovirt-engine.xml.in' file shipped as a part of 'ovirt-engine-backend'
RPM to enable debug logging on the engine.

Let's backup the file before changing it and restore the original after
engine setup.

Signed-off-by: Marcin Sobczyk <msobczyk@redhat.com>
