### PR TITLE
Improve disk_template driver configuration

### DIFF
--- a/common/libvirt-templates/disk_template
+++ b/common/libvirt-templates/disk_template
@@ -1,5 +1,5 @@
 <disk type='file' device='disk'>
-  <driver name='qemu' type='raw' cache='writeback' discard='unmap'/>
+  <driver name='qemu' type='raw' cache='none' io='native' discard='unmap'/>
   <source file='@DISK_FILE@' index='2'/>
   <target dev='@DISK_DEV@' bus='scsi'/>
   <serial>@DISK_SERIAL@</serial>

--- a/common/libvirt-templates/vm_template
+++ b/common/libvirt-templates/vm_template
@@ -45,6 +45,9 @@
       <serial>ost-root-disk</serial>
     </disk>
     @DISKS@
+    <controller type="scsi" index="0" model="virtio-scsi">
+      <driver iothread="1"/>
+    </controller>
     <controller type='usb' model='none'/>
     <serial type='pty'>
       <source path='@SERIALLOG@'/>


### PR DESCRIPTION
Use the same configuration for the disk_template as we use for the root
disk in vm_template. This is more important since the storage vm does
more I/O.

Fixes e2453ad536ef (vm-template: Improve disk driver configuration)