### PR TITLE
lagofy.sh: Fix extra disks format

### DIFF
--- a/lagofy.sh
+++ b/lagofy.sh
@@ -253,8 +253,8 @@ ost_init() {
                 disk_template=$(jqr ".vms[\"${VM_NAME}\"].disks[\"${DISK_DEV}\"].template")
                 DISK_SIZE=$(jqr ".vms[\"${VM_NAME}\"].disks[\"${DISK_DEV}\"].size")
                 [[ -r "${!vm_rootdisk_var}" ]] || { echo -e "\nroot disk ${vm_rootdisk_var}(${!vm_rootdisk_var}) doesn't exist"; return 1; }
-                DISK_FILE="$OST_DEPLOYMENT/images/${VM_NAME}-${DISK_DEV}.qcow2"
-                qemu-img create -q -f qcow2 -o preallocation=metadata "${DISK_FILE}" "${DISK_SIZE}"
+                DISK_FILE="$OST_DEPLOYMENT/images/${VM_NAME}-${DISK_DEV}.raw"
+                qemu-img create -q -f raw "${DISK_FILE}" "${DISK_SIZE}"
                 echo -n "${DISK_DEV}(${DISK_SIZE}) "
                 DISKS+=$(_render ${disk_template} | tr -d "\t\n")
                 (( DISK_SERIAL++ ))


### PR DESCRIPTION
The script was creating a qcow2 disk:

    qemu-img create -f qcow2 -o preallocation=metadata disk.qcow2 100g

This creates an empty qcow2 image with preallocated metadata, so its
file size is actually 101G.

    $ ls -lhs disk.qcow2
    204M -rw-r--r--. 1 nsoffer nsoffer 101G Jul 21 16:52 disk.qcow2

But the disk xml is using raw format:

    <disk type='file' device='disk'>
      <driver name='qemu' type='raw' cache='writeback' discard='unmap'/>
      <source file='/home/jenkins/workspace/ds-ost-baremetal_manual/deployment/images/storage-sda.qcow2' index='2'/>
      ...
    </disk>

So the VM is using the disk as a 101G raw image, overwriting the qcow2
header with actual guest data:

    # qemu-img info /home/jenkins/workspace/ds-ost-baremetal_manual/deployment/images/storage-sda.qcow2
    image: /home/jenkins/workspace/ds-ost-baremetal_manual/deployment/images/storage-sda.qcow2
    file format: raw
    virtual size: 101 GiB (108464701440 bytes)
    disk size: 2.38 GiB

Change the script to use raw format.