### PR TITLE
Update VgpuDialog spinner check for PF4 CSS class names

### DIFF
--- a/ost_utils/selenium/navigation/driver.py
+++ b/ost_utils/selenium/navigation/driver.py
@@ -85,6 +85,19 @@ class Driver:
             lambda: self.is_xpath_present(xpath) and self.driver.find_element(By.XPATH, xpath).is_displayed()
         )
 
+    def is_css_selector_present(self, selector):
+        try:
+            self.retry_if_stale(self.driver.find_element, By.CSS_SELECTOR, selector)
+            return True
+        except NoSuchElementException:
+            return False
+
+    def is_css_selector_displayed(self, selector):
+        return self.retry_if_stale(
+            lambda: self.is_css_selector_present(selector)
+            and self.driver.find_element(By.CSS_SELECTOR, selector).is_displayed()
+        )
+
     def is_button_enabled(self, text):
         return self.is_xpath_enabled(f'//button[text()="{text}"]')
 

--- a/ost_utils/selenium/page_objects/VmDetailView.py
+++ b/ost_utils/selenium/page_objects/VmDetailView.py
@@ -85,7 +85,7 @@ class VmVgpuDialog(Displayable):
         dialog_displayed = self.ovirt_driver.driver.find_element(
             By.CSS_SELECTOR, '.modal-dialog,.pf-c-modal-box'
         ).is_displayed()
-        spinner_displayed = self.ovirt_driver.is_xpath_displayed('//div[contains(@class, "spinner")]')
+        spinner_displayed = self.ovirt_driver.is_css_selector_displayed('#vm-manage-gpu-modal .pf-c-spinner')
         return dialog_displayed and not spinner_displayed
 
     def get_displayable_name(self):


### PR DESCRIPTION
After ovirt-engine-ui-extensions upgraded to PF4 [1], the
test is failing since it looking for the PF3 version of
the Spinner component.  Update the check to look for the
PF4 Spinner component using the CSS_SELECTOR style.