### PR TITLE
engine: Use drop-in for logging configuration

### DIFF
--- a/basic-suite-master/test-scenarios/test_001_initialize_engine.py
+++ b/basic-suite-master/test-scenarios/test_001_initialize_engine.py
@@ -5,31 +5,7 @@
 #
 from __future__ import absolute_import
 
-import os
-import os.path
-
-import pytest
-
 from ost_utils.ansible.collection import engine_setup
-
-
-@pytest.fixture(scope="function")
-def xml_with_debug_enabled(ansible_engine):
-    xml_path = '/usr/share/ovirt-engine/services/ovirt-engine/ovirt-engine.xml.in'
-    xml_tmp_path = f'/tmp/{os.path.basename(xml_path)}'
-    if os.environ.get('ENABLE_DEBUG_LOGGING'):
-        ansible_engine.shell(f'mv {xml_path} {xml_tmp_path} && cp {xml_tmp_path} {xml_path}')
-        ansible_engine.shell(
-            'sed -i '
-            '-e "/.*logger category=\\"org.ovirt\\"/{ n; s/INFO/DEBUG/ }" '
-            '-e "/.*logger category=\\"org.ovirt.engine.core.bll\\"/{ n; s/INFO/DEBUG/ }" '  # noqa: E501
-            '-e "/.*logger category=\\"org.keycloak\\"/{ n; s/INFO/DEBUG/ }" '
-            '-e "/.*<root-logger>/{ n; s/INFO/DEBUG/ }" '
-            f'{xml_path}'
-        )
-    yield
-    if os.environ.get('ENABLE_DEBUG_LOGGING'):
-        ansible_engine.shell(f'mv {xml_tmp_path} {xml_path}')
 
 
 def test_initialize_engine(
@@ -39,7 +15,6 @@ def test_initialize_engine(
     engine_hostname,
     ssh_key_file,
     engine_answer_file_path,
-    xml_with_debug_enabled,
 ):
     engine_setup(
         ansible_engine,

--- a/ost_utils/ansible/collection.py
+++ b/ost_utils/ansible/collection.py
@@ -79,9 +79,21 @@ def engine_setup(
     host_name = socket.gethostname()
     host_ip = socket.gethostbyname(host_name)
 
+    config = f'''\
+SSO_ALTERNATE_ENGINE_FQDNS="${{SSO_ALTERNATE_ENGINE_FQDNS}} {host_ip} {host_name} {engine_ip}"
+'''
+
+    if os.environ.get('ENABLE_DEBUG_LOGGING'):
+        config += '''\
+ORG_OVIRT_LOG_LEVEL="DEBUG"
+KEYCLOAK_LOG_LEVEL="DEBUG"
+CORE_BLL_LOG_LEVEL="DEBUG"
+ROOT_LOG_LEVEL="DEBUG"
+'''
+
     ansible_engine.copy(
-        content=f'SSO_ALTERNATE_ENGINE_FQDNS="${{SSO_ALTERNATE_ENGINE_FQDNS}} {host_ip} {host_name} {engine_ip}"\n',  # noqa: E501
-        dest='/etc/ovirt-engine/engine.conf.d/99-custom-fqdn.conf',
+        content=config.replace('\n', '\\n'),
+        dest='/etc/ovirt-engine/engine.conf.d/99-ost.conf',
         mode='0644',
     )
 


### PR DESCRIPTION
Requires: https://github.com/oVirt/ovirt-engine/pull/553

Signed-off-by: Marcin Sobczyk <msobczyk@redhat.com>
