### PR TITLE
basic: el8stream: Downgrade python on host-0 temporarily

### DIFF
--- a/ost_utils/pytest/fixtures/deployment.py
+++ b/ost_utils/pytest/fixtures/deployment.py
@@ -145,6 +145,12 @@ def deploy(
         if not request.config.getoption('--skip-custom-repos-check') and not deploy_hosted_engine:
             package_mgmt.check_installed_packages(ansible_all)
 
+    # temporary hack to downgrade python on host-0 to investigate https://bugzilla.redhat.com/show_bug.cgi?id=2111187
+    if ost_images_distro == "el8stream":
+        ansible_hosts.shell(
+            '(hostname | grep 0) && dnf install -y --enablerepo baseos platform-python-3.6.8-42.el8 || :'
+        )
+
     # report package versions
     package_mgmt.report_ovirt_packages_versions(ansible_all)
 


### PR DESCRIPTION
We're investigating a problem with vdsm ending up in a deadlock.
This is reported here [1].

Recent changes introduced in python versions '-43' and '-44' look
suspicious:

* Tue Oct 12 2021 Charalampos Stratakis <cstratak@redhat.com> - 3.6.8-44
- Use the monotonic clock for theading.Condition
- Use the monotonic clock for the global interpreter lock
Resolves: rhbz#2003758

* Mon Oct 11 2021 Charalampos Stratakis <cstratak@redhat.com> - 3.6.8-43
- Change shouldRollover() methods of logging.handlers to only rollover regular files
Resolves: rhbz#2009200

so we want to use an older one over the weekend to see if the issue is
still there.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=2111187

Signed-off-by: Marcin Sobczyk <msobczyk@redhat.com>
