### PR TITLE
UI tests: Improve logout

### DIFF
--- a/ost_utils/selenium/navigation/driver.py
+++ b/ost_utils/selenium/navigation/driver.py
@@ -30,6 +30,9 @@ class Driver:
     def get(self, url):
         self.__driver.get(url)
 
+    def refresh(self):
+        self.__driver.refresh()
+
     def quit(self):
         self.__driver.quit()
 

--- a/ost_utils/selenium/page_objects/WebAdminTopMenu.py
+++ b/ost_utils/selenium/page_objects/WebAdminTopMenu.py
@@ -4,8 +4,8 @@
 #
 import logging
 
-from selenium.webdriver.common.by import By
 from .Displayable import Displayable
+from .WelcomeScreen import WelcomeScreen
 
 LOGGER = logging.getLogger(__name__)
 
@@ -15,7 +15,7 @@ class WebAdminTopMenu(Displayable):
         super(WebAdminTopMenu, self).__init__(ovirt_driver)
 
     def is_displayed(self):
-        return self.ovirt_driver.find_element(By.TAG_NAME, 'nav').is_displayed()
+        return self.ovirt_driver.is_css_selector_displayed('nav')
 
     def get_displayable_name(self):
         return 'WebAdmin top menu'
@@ -30,3 +30,21 @@ class WebAdminTopMenu(Displayable):
         )
         self.ovirt_driver.xpath_wait_and_click('User dropdown menu', '//*[@id="HeaderView_userName"]')
         self.ovirt_driver.xpath_wait_and_click('Logout menu', '//*[@id="HeaderView_logoutLink"]')
+
+        self.ovirt_driver.wait_until(
+            'The welcome screen is not displayed after logout', self._welcome_screen_displayed
+        )
+
+    def _welcome_screen_displayed(self):
+        top_menu_displayed = self.is_displayed()
+        welcome_screen_displayed = WelcomeScreen(self.ovirt_driver).is_displayed()
+
+        if welcome_screen_displayed:
+            return True
+        elif not top_menu_displayed:
+            # Page is not fully loaded yet
+            return False
+        else:
+            LOGGER.debug('The top menu is still displayed, refreshing the page')
+            self.ovirt_driver.refresh()
+            return False

--- a/ost_utils/selenium/page_objects/WelcomeScreen.py
+++ b/ost_utils/selenium/page_objects/WelcomeScreen.py
@@ -15,7 +15,7 @@ class WelcomeScreen(Displayable):
         super(WelcomeScreen, self).__init__(ovirt_driver)
 
     def is_displayed(self):
-        return self.ovirt_driver.find_element(By.CLASS_NAME, 'welcome-section').is_displayed()
+        return self.ovirt_driver.is_css_selector_displayed('.welcome-section')
 
     def get_displayable_name(self):
         return 'Welcome screen'


### PR DESCRIPTION
Sometimes when logging out, instead of displaying the welcome screen, the page stays on dashboard. Probable cause is that some queries are still running and interrupt the page redirect.

This page manually refreshes the webadmin so that the welcome screen is displayed.