### PR TITLE
Hide driver

### DIFF
--- a/basic-suite-master/test-scenarios/test_100_basic_ui_sanity.py
+++ b/basic-suite-master/test-scenarios/test_100_basic_ui_sanity.py
@@ -116,7 +116,7 @@ def ovirt_driver(
     try:
         yield ovirt_driver
     finally:
-        ovirt_driver.driver.quit()
+        ovirt_driver.quit()
 
 
 @pytest.fixture(scope="session")
@@ -172,7 +172,7 @@ def save_page_source(ovirt_driver, selenium_artifact_full_path):
 @pytest.fixture(scope="session")
 def save_logs_from_browser(ovirt_driver, selenium_artifact_full_path):
     def save(description):
-        if ovirt_driver.driver.capabilities['browserName'] == 'chrome':
+        if ovirt_driver.get_capability('browserName') == 'chrome':
             ovirt_driver.save_console_log(selenium_artifact_full_path(description, 'txt'))
             ovirt_driver.save_performance_log(selenium_artifact_full_path(description, 'perf.txt'))
 
@@ -506,7 +506,7 @@ def test_logout(ovirt_driver, engine_webadmin_url):
     webadmin_top_menu.wait_for_not_displayed()
 
     # navigate directly to welcome page to prevent problems with redirecting to login page instead of welcome page
-    ovirt_driver.driver.get(engine_webadmin_url)
+    ovirt_driver.get(engine_webadmin_url)
 
     welcome_screen = WelcomeScreen(ovirt_driver)
     welcome_screen.wait_for_displayed()
@@ -554,7 +554,7 @@ def test_grafana(
     engine_fqdn,
 ):
 
-    ovirt_driver.driver.get(engine_webadmin_url)
+    ovirt_driver.get(engine_webadmin_url)
 
     welcome_screen = WelcomeScreen(ovirt_driver)
     welcome_screen.wait_for_displayed()
@@ -571,7 +571,7 @@ def test_grafana(
     save_screenshot('grafana')
 
     # navigate directly to Grafana Configuration/Data Sources page
-    ovirt_driver.driver.get(f'https://{engine_fqdn}/ovirt-engine-grafana/datasources')
+    ovirt_driver.get(f'https://{engine_fqdn}/ovirt-engine-grafana/datasources')
     assert grafana.db_connection()
     save_screenshot('grafana-datasource-connection')
 

--- a/ost_utils/selenium/page_objects/DashboardView.py
+++ b/ost_utils/selenium/page_objects/DashboardView.py
@@ -43,11 +43,11 @@ class DashboardView(Displayable, WithBreadcrumbs, WithNotifications):
         return self.ovirt_driver.execute_in_frame(self.DASHBOARD_IFRAME_SELECTOR, method, *args)
 
     def _is_displayed(self):
-        return self.ovirt_driver.driver.find_element(By.XPATH, '//div[@id="global-dashboard"]').is_displayed()
+        return self.ovirt_driver.find_element(By.XPATH, '//div[@id="global-dashboard"]').is_displayed()
 
     def _get_aggregate_count(self, label):
         return int(
-            self.ovirt_driver.driver.find_element(
+            self.ovirt_driver.find_element(
                 By.XPATH,
                 '//a[span/text() = "' + label + '"]/span[@class="aggregate-status-count"]',
             ).text

--- a/ost_utils/selenium/page_objects/DisksListView.py
+++ b/ost_utils/selenium/page_objects/DisksListView.py
@@ -38,7 +38,7 @@ class DisksListView(EntityListView):
         return self.ovirt_driver.is_button_enabled('Upload')
 
     def get_status(self, entity_name):
-        names_to_ids = self.ovirt_driver.retry_if_stale(self._get_entity_names_to_ids)
+        names_to_ids = self.ovirt_driver.retry_if_known_issue(self._get_entity_names_to_ids)
 
         if entity_name not in names_to_ids:
             raise Exception(f'No {self.entity_type} with the name {entity_name} found')
@@ -47,7 +47,9 @@ class DisksListView(EntityListView):
         # get the id of the status column (column 10)
         name_id = names_to_ids[entity_name]
         status_id = name_id.replace("0_row", "10_row")
-        status_text = self.ovirt_driver.retry_if_stale(lambda: self.ovirt_driver.find_element(By.ID, status_id).text)
+        status_text = self.ovirt_driver.retry_if_known_issue(
+            lambda: self.ovirt_driver.find_element(By.ID, status_id).text
+        )
         return status_text
 
     def upload(self, image_local_path, image_name):

--- a/ost_utils/selenium/page_objects/DisksListView.py
+++ b/ost_utils/selenium/page_objects/DisksListView.py
@@ -47,9 +47,7 @@ class DisksListView(EntityListView):
         # get the id of the status column (column 10)
         name_id = names_to_ids[entity_name]
         status_id = name_id.replace("0_row", "10_row")
-        status_text = self.ovirt_driver.retry_if_stale(
-            lambda: self.ovirt_driver.driver.find_element(By.ID, status_id).text
-        )
+        status_text = self.ovirt_driver.retry_if_stale(lambda: self.ovirt_driver.find_element(By.ID, status_id).text)
         return status_text
 
     def upload(self, image_local_path, image_name):
@@ -62,13 +60,13 @@ class DisksListView(EntityListView):
             self.ovirt_driver.is_xpath_present,
             '//*[@id="UploadImagePopupView_fileUpload"]',
         )
-        self.ovirt_driver.driver.find_element(By.ID, 'UploadImagePopupView_fileUpload').send_keys(image_local_path)
+        self.ovirt_driver.find_element(By.ID, 'UploadImagePopupView_fileUpload').send_keys(image_local_path)
         self.ovirt_driver.wait_until(
             'Upload image dialog is not displayed',
             self.ovirt_driver.is_xpath_displayed,
             '//*[@id="VmDiskPopupWidget_alias"]',
         )
-        self.ovirt_driver.driver.find_element(By.ID, 'VmDiskPopupWidget_alias').send_keys(image_name)
+        self.ovirt_driver.find_element(By.ID, 'VmDiskPopupWidget_alias').send_keys(image_name)
 
         self.ovirt_driver.id_wait_and_click('OK button is not displayed and enabled', 'UploadImagePopupView_Ok')
         self.ovirt_driver.wait_long_until(

--- a/ost_utils/selenium/page_objects/Displayable.py
+++ b/ost_utils/selenium/page_objects/Displayable.py
@@ -23,6 +23,6 @@ class Displayable(WithOvirtDriver):
     def wait_for_not_displayed(self):
         self.ovirt_driver.wait_while(
             self.get_displayable_name() + ' is still displayed',
-            self.ovirt_driver.retry_if_stale,
+            self.ovirt_driver.retry_if_known_issue,
             self.is_displayed,
         )

--- a/ost_utils/selenium/page_objects/EntityListView.py
+++ b/ost_utils/selenium/page_objects/EntityListView.py
@@ -83,7 +83,7 @@ class EntityListView(Displayable, WithBreadcrumbs, WithNotifications):
         return entities
 
     def _get_entity_names_to_ids(self):
-        elements = self.ovirt_driver.driver.find_elements(
+        elements = self.ovirt_driver.find_elements(
             By.XPATH,
             '//a[contains(@id, "' + self.entity_name_table_cell_id_selector + '")]',
         )

--- a/ost_utils/selenium/page_objects/EntityListView.py
+++ b/ost_utils/selenium/page_objects/EntityListView.py
@@ -51,7 +51,7 @@ class EntityListView(Displayable, WithBreadcrumbs, WithNotifications):
 
     def open_detail_view(self, entity_name):
         LOGGER.debug('Open detail of ' + self.entity_type + ' ' + entity_name)
-        names_to_ids = self.ovirt_driver.retry_if_stale(self._get_entity_names_to_ids)
+        names_to_ids = self.ovirt_driver.retry_if_known_issue(self._get_entity_names_to_ids)
 
         if entity_name in names_to_ids:
             self.ovirt_driver.xpath_click(f'//*[@id="{names_to_ids[entity_name]}"]')
@@ -60,7 +60,7 @@ class EntityListView(Displayable, WithBreadcrumbs, WithNotifications):
 
     def select_entity(self, entity_name):
         LOGGER.debug('Select ' + self.entity_type + ' ' + entity_name)
-        names_to_ids = self.ovirt_driver.retry_if_stale(self._get_entity_names_to_ids)
+        names_to_ids = self.ovirt_driver.retry_if_known_issue(self._get_entity_names_to_ids)
 
         if entity_name in names_to_ids:
             # find the parent td and click the td next to it to select the row
@@ -76,7 +76,7 @@ class EntityListView(Displayable, WithBreadcrumbs, WithNotifications):
         time.sleep(1)
 
     def get_entities(self):
-        names_to_ids = self.ovirt_driver.retry_if_stale(self._get_entity_names_to_ids)
+        names_to_ids = self.ovirt_driver.retry_if_known_issue(self._get_entity_names_to_ids)
         entities = []
         for name in names_to_ids:
             entities.append(name)

--- a/ost_utils/selenium/page_objects/Grafana.py
+++ b/ost_utils/selenium/page_objects/Grafana.py
@@ -16,7 +16,7 @@ class Grafana(Displayable):
         super(Grafana, self).__init__(ovirt_driver)
 
     def is_displayed(self):
-        return self.ovirt_driver.driver.find_element(
+        return self.ovirt_driver.find_element(
             By.XPATH,
             '//h1[text()="Welcome to Grafana"] | ' '//span[text()="Welcome to Grafana"]',
         ).is_displayed()
@@ -56,7 +56,7 @@ class Grafana(Displayable):
 
     def is_error_visible(self):
         if self.ovirt_driver.is_xpath_present('//app-notifications-list'):
-            notifications = self.ovirt_driver.driver.find_elements(By.XPATH, '//app-notifications-list/*')
+            notifications = self.ovirt_driver.find_elements(By.XPATH, '//app-notifications-list/*')
             for notification in notifications:
                 if "Error" in notification.text:
                     return True
@@ -68,7 +68,7 @@ class Grafana(Displayable):
         return False
 
     def _is_breadcrumbs_visible(self, menu, submenu):
-        find_element = self.ovirt_driver.driver.find_element
+        find_element = self.ovirt_driver.find_element
         is_breadcrumb_menu_visible = find_element(
             By.XPATH,
             f'//div[@class="navbar-page-btn"]//a[text() = "{menu}"] | ' f'//button[text() = "{menu}"]',

--- a/ost_utils/selenium/page_objects/GrafanaLoginScreen.py
+++ b/ost_utils/selenium/page_objects/GrafanaLoginScreen.py
@@ -18,7 +18,7 @@ class GrafanaLoginScreen(Displayable):
         super(GrafanaLoginScreen, self).__init__(ovirt_driver)
 
     def is_displayed(self):
-        return self.ovirt_driver.driver.find_element(By.XPATH, self.OAUTH_XPATH).is_displayed()
+        return self.ovirt_driver.find_element(By.XPATH, self.OAUTH_XPATH).is_displayed()
 
     def get_displayable_name(self):
         return 'Grafana login screen'

--- a/ost_utils/selenium/page_objects/LoginScreen.py
+++ b/ost_utils/selenium/page_objects/LoginScreen.py
@@ -16,11 +16,11 @@ class LoginScreen(Displayable):
         self._keycloak_enabled = keycloak_enabled
 
     def is_displayed(self):
-        is_user_name_displayed = self.ovirt_driver.driver.find_element(
+        is_user_name_displayed = self.ovirt_driver.find_element(
             By.XPATH,
             '//input[@id="username"]',
         ).is_displayed()
-        is_user_password_displayed = self.ovirt_driver.driver.find_element(
+        is_user_password_displayed = self.ovirt_driver.find_element(
             By.XPATH,
             '//input[@id="password"]',
         ).is_displayed()
@@ -30,13 +30,13 @@ class LoginScreen(Displayable):
         return 'Login screen'
 
     def set_user_name(self, user_name):
-        self.ovirt_driver.driver.find_element(
+        self.ovirt_driver.find_element(
             By.XPATH,
             '//input[@id="username"]',
         ).send_keys(user_name)
 
     def set_user_password(self, user_password):
-        self.ovirt_driver.driver.find_element(
+        self.ovirt_driver.find_element(
             By.XPATH,
             '//input[@id="password"]',
         ).send_keys(user_password)

--- a/ost_utils/selenium/page_objects/VmDetailView.py
+++ b/ost_utils/selenium/page_objects/VmDetailView.py
@@ -30,21 +30,17 @@ class VmDetailView(Displayable, WithBreadcrumbs):
 
     def open_host_devices_tab(self):
         LOGGER.debug('Open host devices tab')
-        self.ovirt_driver.driver.find_element(By.LINK_TEXT, 'Host Devices').click()
+        self.ovirt_driver.find_element(By.LINK_TEXT, 'Host Devices').click()
 
         vm_detail_host_devices_tab = VmDetailHostDevicesTab(self.ovirt_driver)
         vm_detail_host_devices_tab.wait_for_displayed()
         return vm_detail_host_devices_tab
 
     def get_name(self):
-        return self.ovirt_driver.driver.find_element(
-            By.ID, 'SubTabVirtualMachineGeneralView_form_col0_row0_value'
-        ).text
+        return self.ovirt_driver.find_element(By.ID, 'SubTabVirtualMachineGeneralView_form_col0_row0_value').text
 
     def get_status(self):
-        return self.ovirt_driver.driver.find_element(
-            By.ID, 'SubTabVirtualMachineGeneralView_form_col0_row2_value'
-        ).text
+        return self.ovirt_driver.find_element(By.ID, 'SubTabVirtualMachineGeneralView_form_col0_row2_value').text
 
     def wait_for_statuses(self, statuses):
         LOGGER.debug('Waiting for one of the specified VM statuses')
@@ -59,7 +55,7 @@ class VmDetailHostDevicesTab(Displayable):
         super(VmDetailHostDevicesTab, self).__init__(ovirt_driver)
 
     def is_displayed(self):
-        return self.ovirt_driver.driver.find_element(
+        return self.ovirt_driver.find_element(
             By.XPATH, '//ul/li[@class="active"]/a[@href="#vms-host_devices"]'
         ).is_displayed()
 
@@ -68,7 +64,7 @@ class VmDetailHostDevicesTab(Displayable):
 
     def open_manage_vgpu_dialog(self):
         LOGGER.debug('Open vGPU dialog')
-        self.ovirt_driver.driver.find_element(
+        self.ovirt_driver.find_element(
             By.XPATH,
             '//button[text()="Manage vGPU"]',
         ).click()
@@ -82,7 +78,7 @@ class VmVgpuDialog(Displayable):
         super(VmVgpuDialog, self).__init__(ovirt_driver)
 
     def is_displayed(self):
-        dialog_displayed = self.ovirt_driver.driver.find_element(
+        dialog_displayed = self.ovirt_driver.find_element(
             By.CSS_SELECTOR, '.modal-dialog,.pf-c-modal-box'
         ).is_displayed()
         spinner_displayed = self.ovirt_driver.is_css_selector_displayed('#vm-manage-gpu-modal .pf-c-spinner')
@@ -92,13 +88,13 @@ class VmVgpuDialog(Displayable):
         return 'Manage vGPU dialog'
 
     def get_title(self):
-        return self.ovirt_driver.driver.find_element(
+        return self.ovirt_driver.find_element(
             By.CSS_SELECTOR,
             'h4.modal-title,h1.pf-c-title,h1.pf-c-modal-box__title',
         ).text
 
     def get_row_data(self, row_index):
-        row_tds = self.ovirt_driver.driver.find_elements(
+        row_tds = self.ovirt_driver.find_elements(
             By.XPATH,
             '//table[contains(@class, "vgpu-table")]/' f'tbody[{row_index}]/tr/td',
         )
@@ -106,7 +102,7 @@ class VmVgpuDialog(Displayable):
 
     def cancel(self):
         LOGGER.debug('Cancel vGPU dialog')
-        self.ovirt_driver.driver.find_element(
+        self.ovirt_driver.find_element(
             By.XPATH,
             '//div[@class="modal-footer"]//button[. = "Cancel"]|'
             '//div[@class="pf-c-modal-box__footer"]'

--- a/ost_utils/selenium/page_objects/VmPortal.py
+++ b/ost_utils/selenium/page_objects/VmPortal.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
 from selenium.webdriver.common.by import By
-from selenium.webdriver.common.action_chains import ActionChains
 from .Displayable import Displayable
 
 
@@ -20,18 +19,16 @@ class VmPortal(Displayable):
         return 'VM Portal'
 
     def get_vm_status(self, vm_name):
-        return self.ovirt_driver.driver.find_element(By.ID, 'vm-' + vm_name + '-status').text.strip()
+        return self.ovirt_driver.find_element(By.ID, 'vm-' + vm_name + '-status').text.strip()
 
     def get_vm_count(self):
-        return int(
-            self.ovirt_driver.driver.find_element(By.XPATH, "//div[@class='col-sm-12']/h5").text.strip().split(' ')[0]
-        )
+        return int(self.ovirt_driver.find_element(By.XPATH, "//div[@class='col-sm-12']/h5").text.strip().split(' ')[0])
 
     def logout(self):
         self.ovirt_driver.xpath_wait_and_click('User dropdown menu', '//*[@id="usermenu-user"]')
         self.ovirt_driver.wait_until('Logout menu is present', self.ovirt_driver.is_id_present, 'usermenu-logout')
 
-        logout_menu = self.ovirt_driver.driver.find_element(By.XPATH, '//*[@id="usermenu-logout"]')
-        ActionChains(self.ovirt_driver.driver).move_to_element(logout_menu).click(logout_menu).perform()
+        logout_menu = self.ovirt_driver.find_element(By.XPATH, '//*[@id="usermenu-logout"]')
+        self.ovirt_driver.create_action_chains().move_to_element(logout_menu).click(logout_menu).perform()
 
         self.ovirt_driver.wait_while('Vm portal still displayed', self.is_displayed)

--- a/ost_utils/selenium/page_objects/WebAdminLeftMenu.py
+++ b/ost_utils/selenium/page_objects/WebAdminLeftMenu.py
@@ -4,7 +4,6 @@
 #
 import logging
 
-from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.common.by import By
 from .Displayable import Displayable
 from .VmListView import VmListView
@@ -103,8 +102,8 @@ class WebAdminLeftMenu(Displayable):
         self._open_menu('MenuView_storageTab', menu_name, menu_id)
 
     def _open_menu(self, menu_group, menu_name, menu_id):
-        menu_element = self.ovirt_driver.driver.find_element(By.ID, menu_group)
-        submenu_element = self.ovirt_driver.driver.find_element(By.ID, menu_id)
+        menu_element = self.ovirt_driver.find_element(By.ID, menu_group)
+        submenu_element = self.ovirt_driver.find_element(By.ID, menu_id)
         self.ovirt_driver.wait_until(
             f'sub menu "{menu_name}" is visible  in the left menu',
             self._submenu_is_displayed,
@@ -114,5 +113,5 @@ class WebAdminLeftMenu(Displayable):
         submenu_element.click()
 
     def _submenu_is_displayed(self, menu_element, submenu_element):
-        ActionChains(self.ovirt_driver.driver).move_to_element(menu_element).perform()
+        self.ovirt_driver.create_action_chains().move_to_element(menu_element).perform()
         return submenu_element.is_displayed()

--- a/ost_utils/selenium/page_objects/WebAdminTopMenu.py
+++ b/ost_utils/selenium/page_objects/WebAdminTopMenu.py
@@ -15,7 +15,7 @@ class WebAdminTopMenu(Displayable):
         super(WebAdminTopMenu, self).__init__(ovirt_driver)
 
     def is_displayed(self):
-        return self.ovirt_driver.driver.find_element(By.TAG_NAME, 'nav').is_displayed()
+        return self.ovirt_driver.find_element(By.TAG_NAME, 'nav').is_displayed()
 
     def get_displayable_name(self):
         return 'WebAdmin top menu'
@@ -25,7 +25,7 @@ class WebAdminTopMenu(Displayable):
         # overriding the window.onbeforeunload to prevent an intermittend
         # alert saying
         # Leave site? Changes you made may not be saved.
-        self.ovirt_driver.driver.execute_script(
+        self.ovirt_driver.execute_script(
             'window.onbeforeunload = function() ' '{console.log("overriden window.onbeforeunload called")};'
         )
         self.ovirt_driver.xpath_wait_and_click('User dropdown menu', '//*[@id="HeaderView_userName"]')

--- a/ost_utils/selenium/page_objects/WelcomeScreen.py
+++ b/ost_utils/selenium/page_objects/WelcomeScreen.py
@@ -15,22 +15,22 @@ class WelcomeScreen(Displayable):
         super(WelcomeScreen, self).__init__(ovirt_driver)
 
     def is_displayed(self):
-        return self.ovirt_driver.driver.find_element(By.CLASS_NAME, 'welcome-section').is_displayed()
+        return self.ovirt_driver.find_element(By.CLASS_NAME, 'welcome-section').is_displayed()
 
     def get_displayable_name(self):
         return 'Welcome screen'
 
     def open_administration_portal(self):
         LOGGER.debug('Open Administration portal')
-        self.ovirt_driver.driver.find_element(By.ID, 'WelcomePage_webadmin').click()
+        self.ovirt_driver.find_element(By.ID, 'WelcomePage_webadmin').click()
 
     def open_user_portal(self):
         LOGGER.debug('Open User portal')
-        self.ovirt_driver.driver.find_element(By.ID, 'WelcomePage_userportal_webui').click()
+        self.ovirt_driver.find_element(By.ID, 'WelcomePage_userportal_webui').click()
 
     def open_monitoring_portal(self):
         LOGGER.debug('Open Monitoring portal')
-        self.ovirt_driver.driver.find_element(By.ID, 'WelcomePage_monitoring_grafana').click()
+        self.ovirt_driver.find_element(By.ID, 'WelcomePage_monitoring_grafana').click()
 
     def logout(self):
         self.ovirt_driver.xpath_wait_and_click('User dropdown menu', '//*[@id="sso-dropdown-toggle"]')
@@ -38,20 +38,18 @@ class WelcomeScreen(Displayable):
 
     def is_user_logged_in(self, username):
         return (
-            self.ovirt_driver.driver.find_element(By.XPATH, '//*[@id="sso-dropdown-toggle"]')
-            .text.strip()
-            .split('@')[0]
+            self.ovirt_driver.find_element(By.XPATH, '//*[@id="sso-dropdown-toggle"]').text.strip().split('@')[0]
             == username
         )
 
     def is_user_logged_out(self):
         return (
-            self.ovirt_driver.driver.find_element(By.XPATH, '//button[@id="sso-dropdown-toggle"]/span').text.strip()
+            self.ovirt_driver.find_element(By.XPATH, '//button[@id="sso-dropdown-toggle"]/span').text.strip()
             == 'Not logged in'
         )
 
     def is_error_message_displayed(self):
-        return self.ovirt_driver.driver.find_element(By.CLASS_NAME, 'session-error').is_displayed()
+        return self.ovirt_driver.find_element(By.CLASS_NAME, 'session-error').is_displayed()
 
     def get_error_message(self):
-        return self.ovirt_driver.driver.find_element(By.CLASS_NAME, 'pf-c-alert__title').text.strip()
+        return self.ovirt_driver.find_element(By.CLASS_NAME, 'pf-c-alert__title').text.strip()

--- a/ost_utils/selenium/page_objects/WithBreadcrumbs.py
+++ b/ost_utils/selenium/page_objects/WithBreadcrumbs.py
@@ -11,7 +11,7 @@ class WithBreadcrumbs(WithOvirtDriver):
         return self.ovirt_driver.retry_if_stale(self._get_breadcrumbs)
 
     def _get_breadcrumbs(self):
-        breadcrumbs_elements = self.ovirt_driver.driver.find_elements(By.CSS_SELECTOR, 'ol.breadcrumb > li')
+        breadcrumbs_elements = self.ovirt_driver.find_elements(By.CSS_SELECTOR, 'ol.breadcrumb > li')
 
         breadcrumbs = []
         for breadcrumbs_element in breadcrumbs_elements:

--- a/ost_utils/selenium/page_objects/WithBreadcrumbs.py
+++ b/ost_utils/selenium/page_objects/WithBreadcrumbs.py
@@ -8,7 +8,7 @@ from .WithOvirtDriver import WithOvirtDriver
 
 class WithBreadcrumbs(WithOvirtDriver):
     def get_breadcrumbs(self):
-        return self.ovirt_driver.retry_if_stale(self._get_breadcrumbs)
+        return self.ovirt_driver.retry_if_known_issue(self._get_breadcrumbs)
 
     def _get_breadcrumbs(self):
         breadcrumbs_elements = self.ovirt_driver.find_elements(By.CSS_SELECTOR, 'ol.breadcrumb > li')

--- a/ost_utils/selenium/page_objects/WithNotifications.py
+++ b/ost_utils/selenium/page_objects/WithNotifications.py
@@ -11,15 +11,10 @@ LOGGER = logging.getLogger(__name__)
 
 class WithNotifications(WithOvirtDriver):
     def is_error_notification_visible(self):
-        xpath = '//div[contains(@class, "alert-danger")]'
-        return self.ovirt_driver.retry_if_stale(
-            self.ovirt_driver.is_xpath_present, xpath
-        ) and self.ovirt_driver.retry_if_stale(self.ovirt_driver.is_xpath_displayed, xpath)
+        return self.ovirt_driver.is_xpath_displayed('//div[contains(@class, "alert-danger")]')
 
     def _is_notification_displayed(self):
-        xpath = '//a[@class="notif_dismissButton"]'
-        result = self.ovirt_driver.is_xpath_present(xpath) and self.ovirt_driver.is_xpath_displayed(xpath)
-        return result
+        return self.ovirt_driver.is_xpath_displayed('//a[@class="notif_dismissButton"]')
 
     def close_notification_safely(self):
         xpath = '//a[@class="notif_dismissButton"]'


### PR DESCRIPTION
 UI tests: do not allow direct access to selenium webdriver

This patch makes the selenium driver instance private so that the clients are forced to use ovirt driver. This way we can better handle specific errors. The patch enhances the find_element(s) method with retry for known issues