### PR TITLE
UI tests: Fix login screen after logout

### DIFF
--- a/basic-suite-master/test-scenarios/test_100_basic_ui_sanity.py
+++ b/basic-suite-master/test-scenarios/test_100_basic_ui_sanity.py
@@ -206,7 +206,6 @@ def test_non_admin_login_to_webadmin(
     ovirt_driver,
     nonadmin_username,
     nonadmin_password,
-    engine_webadmin_url,
     user_login,
 ):
     welcome_screen = WelcomeScreen(ovirt_driver)
@@ -576,21 +575,14 @@ def test_dashboard(ovirt_driver):
     assert dashboard.events_count() > 0
 
 
-def test_logout(ovirt_driver, engine_webadmin_url):
+def test_logout(ovirt_driver, engine_webadmin_url, keycloak_enabled):
+    login_screen = LoginScreen(ovirt_driver, keycloak_enabled)
+    welcome_screen = WelcomeScreen(ovirt_driver, engine_webadmin_url)
+
     webadmin_menu = WebAdminTopMenu(ovirt_driver)
     webadmin_menu.wait_for_displayed()
-    webadmin_menu.logout()
+    webadmin_menu.logout(welcome_screen, login_screen)
 
-    webadmin_left_menu = WebAdminLeftMenu(ovirt_driver)
-    webadmin_left_menu.wait_for_not_displayed()
-
-    webadmin_top_menu = WebAdminTopMenu(ovirt_driver)
-    webadmin_top_menu.wait_for_not_displayed()
-
-    # navigate directly to welcome page to prevent problems with redirecting to login page instead of welcome page
-    ovirt_driver.get(engine_webadmin_url)
-
-    welcome_screen = WelcomeScreen(ovirt_driver)
     welcome_screen.wait_for_displayed()
     assert welcome_screen.is_user_logged_out()
 
@@ -600,7 +592,6 @@ def test_userportal(
     nonadmin_username,
     nonadmin_password,
     user_login,
-    engine_webadmin_url,
     save_screenshot,
 ):
     welcome_screen = WelcomeScreen(ovirt_driver)
@@ -636,9 +627,8 @@ def test_grafana(
     engine_fqdn,
 ):
 
-    ovirt_driver.get(engine_webadmin_url)
-
-    welcome_screen = WelcomeScreen(ovirt_driver)
+    welcome_screen = WelcomeScreen(ovirt_driver, engine_webadmin_url)
+    welcome_screen.load()
     welcome_screen.wait_for_displayed()
     welcome_screen.open_monitoring_portal()
 

--- a/ost_utils/selenium/page_objects/LoginScreen.py
+++ b/ost_utils/selenium/page_objects/LoginScreen.py
@@ -16,14 +16,8 @@ class LoginScreen(Displayable):
         self._keycloak_enabled = keycloak_enabled
 
     def is_displayed(self):
-        is_user_name_displayed = self.ovirt_driver.find_element(
-            By.XPATH,
-            '//input[@id="username"]',
-        ).is_displayed()
-        is_user_password_displayed = self.ovirt_driver.find_element(
-            By.XPATH,
-            '//input[@id="password"]',
-        ).is_displayed()
+        is_user_name_displayed = self.ovirt_driver.is_xpath_displayed('//input[@id="username"]')
+        is_user_password_displayed = self.ovirt_driver.is_xpath_displayed('//input[@id="password"]')
         return is_user_name_displayed and is_user_password_displayed
 
     def get_displayable_name(self):

--- a/ost_utils/selenium/page_objects/WebAdminTopMenu.py
+++ b/ost_utils/selenium/page_objects/WebAdminTopMenu.py
@@ -5,7 +5,6 @@
 import logging
 
 from .Displayable import Displayable
-from .WelcomeScreen import WelcomeScreen
 
 LOGGER = logging.getLogger(__name__)
 
@@ -20,7 +19,7 @@ class WebAdminTopMenu(Displayable):
     def get_displayable_name(self):
         return 'WebAdmin top menu'
 
-    def logout(self):
+    def logout(self, welcome_screen, login_screen):
         LOGGER.debug('Log out')
         # overriding the window.onbeforeunload to prevent an intermittend
         # alert saying
@@ -32,16 +31,20 @@ class WebAdminTopMenu(Displayable):
         self.ovirt_driver.xpath_wait_and_click('Logout menu', '//*[@id="HeaderView_logoutLink"]')
 
         self.ovirt_driver.wait_until(
-            'The welcome screen is not displayed after logout', self._welcome_screen_displayed
+            'The welcome screen is not displayed after logout',
+            self._welcome_screen_displayed,
+            welcome_screen,
+            login_screen,
         )
 
-    def _welcome_screen_displayed(self):
-        top_menu_displayed = self.is_displayed()
-        welcome_screen_displayed = WelcomeScreen(self.ovirt_driver).is_displayed()
-
-        if welcome_screen_displayed:
+    def _welcome_screen_displayed(self, welcome_screen, login_screen):
+        if welcome_screen.is_displayed():
             return True
-        elif not top_menu_displayed:
+        elif login_screen.is_displayed():
+            LOGGER.debug('The login page is displayed, navigating directly to the welcome page')
+            welcome_screen.load()
+            return False
+        elif not self.is_displayed():
             # Page is not fully loaded yet
             return False
         else:

--- a/ost_utils/selenium/page_objects/WelcomeScreen.py
+++ b/ost_utils/selenium/page_objects/WelcomeScreen.py
@@ -11,14 +11,20 @@ LOGGER = logging.getLogger(__name__)
 
 
 class WelcomeScreen(Displayable):
-    def __init__(self, ovirt_driver):
+    def __init__(self, ovirt_driver, url=None):
         super(WelcomeScreen, self).__init__(ovirt_driver)
+        self.url = url
 
     def is_displayed(self):
         return self.ovirt_driver.is_css_selector_displayed('.welcome-section')
 
     def get_displayable_name(self):
         return 'Welcome screen'
+
+    def load(self):
+        if self.url is None:
+            raise Exception('Cannot load welcome screen, URL is not defined')
+        self.ovirt_driver.get(self.url)
 
     def open_administration_portal(self):
         LOGGER.debug('Open Administration portal')


### PR DESCRIPTION
Sometimes, the login screen is displayed after the logout. In those case, navigate directly to the welcome screen so that we end up consistently on the welcome screen after logout.