### PR TITLE
UI tests: Move directly to welcome screen after logout

### DIFF
--- a/basic-suite-master/test-scenarios/test_100_basic_ui_sanity.py
+++ b/basic-suite-master/test-scenarios/test_100_basic_ui_sanity.py
@@ -581,17 +581,12 @@ def test_logout(ovirt_driver, engine_webadmin_url):
     webadmin_menu.wait_for_displayed()
     webadmin_menu.logout()
 
-    webadmin_left_menu = WebAdminLeftMenu(ovirt_driver)
-    webadmin_left_menu.wait_for_not_displayed()
-
-    webadmin_top_menu = WebAdminTopMenu(ovirt_driver)
-    webadmin_top_menu.wait_for_not_displayed()
-
     # navigate directly to welcome page to prevent problems with redirecting to login page instead of welcome page
     ovirt_driver.get(engine_webadmin_url)
 
     welcome_screen = WelcomeScreen(ovirt_driver)
     welcome_screen.wait_for_displayed()
+    welcome_screen.wait_for_user_logged_out()
     assert welcome_screen.is_user_logged_out()
 
 

--- a/ost_utils/selenium/page_objects/WebAdminTopMenu.py
+++ b/ost_utils/selenium/page_objects/WebAdminTopMenu.py
@@ -5,7 +5,6 @@
 import logging
 
 from .Displayable import Displayable
-from .WelcomeScreen import WelcomeScreen
 
 LOGGER = logging.getLogger(__name__)
 
@@ -30,21 +29,3 @@ class WebAdminTopMenu(Displayable):
         )
         self.ovirt_driver.xpath_wait_and_click('User dropdown menu', '//*[@id="HeaderView_userName"]')
         self.ovirt_driver.xpath_wait_and_click('Logout menu', '//*[@id="HeaderView_logoutLink"]')
-
-        self.ovirt_driver.wait_until(
-            'The welcome screen is not displayed after logout', self._welcome_screen_displayed
-        )
-
-    def _welcome_screen_displayed(self):
-        top_menu_displayed = self.is_displayed()
-        welcome_screen_displayed = WelcomeScreen(self.ovirt_driver).is_displayed()
-
-        if welcome_screen_displayed:
-            return True
-        elif not top_menu_displayed:
-            # Page is not fully loaded yet
-            return False
-        else:
-            LOGGER.debug('The top menu is still displayed, refreshing the page')
-            self.ovirt_driver.refresh()
-            return False

--- a/ost_utils/selenium/page_objects/WelcomeScreen.py
+++ b/ost_utils/selenium/page_objects/WelcomeScreen.py
@@ -48,6 +48,16 @@ class WelcomeScreen(Displayable):
             == 'Not logged in'
         )
 
+    def wait_for_user_logged_out(self):
+        if self.is_user_logged_out():
+            return True
+        self.ovirt_driver.wait_until('User is still logged in', self._user_logged_out_wait_condition)
+
+    def _user_logged_out_wait_condition(self):
+        self.ovirt_driver.refresh()
+        self.wait_for_displayed()
+        return self.is_user_logged_out()
+
     def is_error_message_displayed(self):
         return self.ovirt_driver.find_element(By.CLASS_NAME, 'session-error').is_displayed()
 


### PR DESCRIPTION
After the logout, the behavior is not deterministic. Sometimes is the user redirected to welcome screen, sometimes to login screen and somtimes it stays on the Webadmin dashboard for a while.

This patch navigates to the welcome screen after pressing log out, and if necessary, reloads and waits until the user is logged out.