### PR TITLE
trial: Disable two tests temporarily

### DIFF
--- a/basic-suite-master/test-scenarios/test_007_sd_reattach.py
+++ b/basic-suite-master/test-scenarios/test_007_sd_reattach.py
@@ -7,6 +7,8 @@ from __future__ import absolute_import
 
 import ovirtsdk4
 
+import pytest
+
 from ost_utils import assert_utils
 from ost_utils import engine_utils
 from ost_utils import test_utils
@@ -103,6 +105,7 @@ def test_reattach_storage_domain(engine_api):
 
 
 @order_by(_TEST_LIST)
+@pytest.mark.skipif(True, reason="test disabled temporarily to investigate hanging vdsm problem")
 def test_import_lost_vm(engine_api):
     engine = engine_api.system_service()
     sd = test_utils.get_attached_storage_domain(engine, SD_SECOND_NFS_NAME, service=True)
@@ -130,6 +133,7 @@ def test_import_lost_vm(engine_api):
 
 
 @order_by(_TEST_LIST)
+@pytest.mark.skipif(True, reason="test disabled temporarily to investigate hanging vdsm problem")
 def test_import_floating_disk(engine_api):
     engine = engine_api.system_service()
     dc_service = test_utils.data_center_service(engine, DC_NAME)

--- a/basic-suite-master/test-scenarios/test_100_basic_ui_sanity.py
+++ b/basic-suite-master/test-scenarios/test_100_basic_ui_sanity.py
@@ -572,7 +572,7 @@ def test_dashboard(ovirt_driver):
     assert dashboard.clusters_count() is 1
     assert dashboard.hosts_count() is 2
     assert dashboard.storage_domains_count() is 3
-    assert dashboard.vm_count() is 5
+    assert dashboard.vm_count() is 4
     assert dashboard.events_count() > 0
 
 


### PR DESCRIPTION
In an attempt to solve the problem of vdsm ending up in a deadlock we're
temporarily disabling two tests around the problematic area. The goal is
to see whether these tests affect the outcome and if the issue is still
visible in CI after a couple of days.

Signed-off-by: Marcin Sobczyk <msobczyk@redhat.com>
