### PR TITLE
Revert "trial: Disable two tests temporarily"

### DIFF
--- a/basic-suite-master/test-scenarios/test_007_sd_reattach.py
+++ b/basic-suite-master/test-scenarios/test_007_sd_reattach.py
@@ -7,8 +7,6 @@ from __future__ import absolute_import
 
 import ovirtsdk4
 
-import pytest
-
 from ost_utils import assert_utils
 from ost_utils import engine_utils
 from ost_utils import test_utils
@@ -105,7 +103,6 @@ def test_reattach_storage_domain(engine_api):
 
 
 @order_by(_TEST_LIST)
-@pytest.mark.skipif(True, reason="test disabled temporarily to investigate hanging vdsm problem")
 def test_import_lost_vm(engine_api):
     engine = engine_api.system_service()
     sd = test_utils.get_attached_storage_domain(engine, SD_SECOND_NFS_NAME, service=True)
@@ -133,7 +130,6 @@ def test_import_lost_vm(engine_api):
 
 
 @order_by(_TEST_LIST)
-@pytest.mark.skipif(True, reason="test disabled temporarily to investigate hanging vdsm problem")
 def test_import_floating_disk(engine_api):
     engine = engine_api.system_service()
     dc_service = test_utils.data_center_service(engine, DC_NAME)

--- a/basic-suite-master/test-scenarios/test_100_basic_ui_sanity.py
+++ b/basic-suite-master/test-scenarios/test_100_basic_ui_sanity.py
@@ -572,7 +572,7 @@ def test_dashboard(ovirt_driver):
     assert dashboard.clusters_count() is 1
     assert dashboard.hosts_count() is 2
     assert dashboard.storage_domains_count() is 3
-    assert dashboard.vm_count() is 4
+    assert dashboard.vm_count() is 5
     assert dashboard.events_count() > 0
 
 


### PR DESCRIPTION
Reverts oVirt/ovirt-system-tests#249 . Commenting out those 2 tests didn't help - we still observe the same failures.