### PR TITLE
trial: Disable tests for detaching storage domain

### DIFF
--- a/basic-suite-master/test-scenarios/test_007_sd_reattach.py
+++ b/basic-suite-master/test-scenarios/test_007_sd_reattach.py
@@ -37,6 +37,7 @@ def _mac_value(mac):
 
 
 @order_by(_TEST_LIST)
+@pytest.mark.skipif(True, reason="test disabled temporarily to investigate hanging vdsm problem")
 def test_deactivate_storage_domain(engine_api):
     # TODO: this also seems to leave running tasks behind which break the deactivation.
     # TODO: it should be tested in multiple runs or properly waited for.
@@ -77,6 +78,7 @@ def test_deactivate_storage_domain(engine_api):
 
 
 @order_by(_TEST_LIST)
+@pytest.mark.skipif(True, reason="test disabled temporarily to investigate hanging vdsm problem")
 def test_detach_storage_domain(engine_api):
     engine = engine_api.system_service()
     dc = test_utils.data_center_service(engine, DC_NAME)
@@ -90,6 +92,7 @@ def test_detach_storage_domain(engine_api):
 
 
 @order_by(_TEST_LIST)
+@pytest.mark.skipif(True, reason="test disabled temporarily to investigate hanging vdsm problem")
 def test_reattach_storage_domain(engine_api):
     VnicSetup.vnic_setup().remove_some_profiles_and_networks()
     engine = engine_api.system_service()

--- a/basic-suite-master/test-scenarios/test_100_basic_ui_sanity.py
+++ b/basic-suite-master/test-scenarios/test_100_basic_ui_sanity.py
@@ -578,7 +578,7 @@ def test_dashboard(ovirt_driver):
     assert dashboard.clusters_count() is 1
     assert dashboard.hosts_count() is 2
     assert dashboard.storage_domains_count() is 3
-    assert dashboard.vm_count() is 4
+    assert dashboard.vm_count() is 5
     assert dashboard.events_count() > 0
 
 


### PR DESCRIPTION
This patch is a continuation of effort started in [1].
After [1] was merged we still observed the issues of vdsm ending
up in a deadlock. Now we're trying to disable other tests to see
if it affects the outcome.

[1] https://github.com/oVirt/ovirt-system-tests/pull/249

Signed-off-by: Marcin Sobczyk <msobczyk@redhat.com>
