### PR TITLE
UI tests: change checked messages for cluster upgrade

### DIFF
--- a/basic-suite-master/test-scenarios/test_100_basic_ui_sanity.py
+++ b/basic-suite-master/test-scenarios/test_100_basic_ui_sanity.py
@@ -331,8 +331,10 @@ def test_cluster_upgrade(
     # cluster is set to cluster_maintenance policy
     assert cluster_service.get().scheduling_policy.id == cluster_maintenance_schedulling_policy_id
 
-    assert assert_utils.true_within_short(lambda: events_view.events_contain(f'Check for update of host {host0_name}'))
-    assert assert_utils.true_within_short(lambda: events_view.events_contain(f'Check for update of host {host1_name}'))
+    # there could be two messages - "Check for update" or "Update" for the host depending on
+    # whether there are updates available and if the updates have been retrieved before
+    assert assert_utils.true_within_short(lambda: events_view.events_contain(f'update of host {host0_name}'))
+    assert assert_utils.true_within_short(lambda: events_view.events_contain(f'update of host {host1_name}'))
     assert assert_utils.true_within_short(
         lambda: events_view.events_contain(f'Upgrade of cluster {ost_cluster_name} finished successfully')
     )

--- a/ost_utils/selenium/page_objects/EventsView.py
+++ b/ost_utils/selenium/page_objects/EventsView.py
@@ -28,7 +28,7 @@ class EventsView(Displayable, WithBreadcrumbs):
         return self.ovirt_driver.retry_if_known_issue(self._get_events)
 
     def events_contain(self, event_substring):
-        return any(event_substring in event for event in self.get_events())
+        return any(event_substring.lower() in event.lower() for event in self.get_events())
 
     def _get_events(self):
         events_entities = self.ovirt_driver.find_elements(


### PR DESCRIPTION
During the cluster upgrade, it is possible to have either "Check for update of host XY" or "Update of host XY" messages.
Both are correct from the test point of view (we do not care if the update is actually performed, we want to make sure
that both hosts are checked for update / updated) 