### PR TITLE
UI tests: fix problem with logout from webadmin

### DIFF
--- a/basic-suite-master/test-scenarios/test_100_basic_ui_sanity.py
+++ b/basic-suite-master/test-scenarios/test_100_basic_ui_sanity.py
@@ -681,7 +681,7 @@ def test_dashboard(ovirt_driver):
     assert dashboard.events_count() > 0
 
 
-def test_logout(ovirt_driver, engine_webadmin_url):
+def test_logout(ovirt_driver, engine_webadmin_url, keycloak_enabled):
     webadmin_menu = WebAdminTopMenu(ovirt_driver)
     webadmin_menu.wait_for_displayed()
     webadmin_menu.logout()
@@ -693,6 +693,10 @@ def test_logout(ovirt_driver, engine_webadmin_url):
     welcome_screen.wait_for_displayed()
     welcome_screen.wait_for_user_logged_out()
     assert welcome_screen.is_user_logged_out()
+
+    if keycloak_enabled:
+        # delete all cookies to workaround not logging out from the Keycloak properly
+        ovirt_driver.delete_all_cookies()
 
 
 def test_userportal(

--- a/ost_utils/selenium/navigation/driver.py
+++ b/ost_utils/selenium/navigation/driver.py
@@ -33,6 +33,9 @@ class Driver:
     def refresh(self):
         self.retry_if_known_issue(self.__driver.refresh)
 
+    def delete_all_cookies(self):
+        self.retry_if_known_issue(self.__driver.delete_all_cookies)
+
     def quit(self):
         self.retry_if_known_issue(self.__driver.quit)
 


### PR DESCRIPTION
When using Keycloak, the tests sometimes fail because the user is not logged out properly and the admin
stays logged in.