### PR TITLE
requirements: drop ansible-navigator

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,5 @@
 # PIP requirements for OST
 ovirt-engine-sdk-python>=4.5.0
-# A temporary workaround to run navigator with 'subprocess' runner mode, until
-# as the default 'pexpect' is unreliable
-# TODO: Revert once it's fixed:
-# https://github.com/ansible/ansible-navigator/issues/606
-git+https://github.com/didib/ansible-navigator.git@671bd6c9#egg=ansible-navigator
 ansible-runner
 pytest==6.2.2
 # basic suite deps


### PR DESCRIPTION
we stopped using it completely because it was not reliable
