### PR TITLE
Verify that snmp traps works after restart

### DIFF
--- a/basic-suite-master/test-scenarios/test_002_bootstrap.py
+++ b/basic-suite-master/test-scenarios/test_002_bootstrap.py
@@ -144,6 +144,7 @@ _TEST_LIST = [
     "test_verify_add_all_hosts",
     "test_generate_openscap_report",
     "test_verify_engine_backup",
+    "test_verify_notifier_restart",
     "test_upload_cirros_image",
     "test_create_cirros_template",
     "test_complete_hosts_setup",
@@ -159,6 +160,7 @@ _TEST_LIST = [
     "test_verify_uploaded_image_and_template",
     "test_add_nonadmin_user",
     "test_add_vm_permissions_to_user",
+    "test_verify_notifier_trap",
 ]
 
 
@@ -1171,6 +1173,31 @@ def test_verify_engine_backup(ansible_engine, engine_api, engine_fqdn, engine_do
     assert assert_utils.equals_within_short(
         lambda: engine_download(url), b"DB Up!Welcome to Health Status!", allowed_exceptions
     )
+
+
+@order_by(_TEST_LIST)
+def test_verify_notifier_restart(ansible_engine, engine_api, ost_dc_name):
+    if ost_dc_name != engine_object_names.TEST_DC_NAME:
+        pytest.skip(' [2020-12-14] Do not test ovirt-engine-notifier on HE suites')
+    ansible_engine.systemd(name='ovirt-engine-notifier', state='stopped')
+    ansible_engine.systemd(name='ovirt-engine-notifier', state='started')
+    # Add a new tag to get a new trap
+    engine = engine_api.system_service()
+    tags_service = engine.tags_service()
+    assert tags_service.add(
+        sdk4.types.Tag(
+            name='notifiertag',
+            description='New tag for ovirt-engine-notifier test after restart',
+        ),
+    )
+
+
+@order_by(_TEST_LIST)
+def test_verify_notifier_trap(ansible_engine, engine_api, ost_dc_name):
+    if ost_dc_name != engine_object_names.TEST_DC_NAME:
+        pytest.skip(' [2020-12-14] Do not test ovirt-engine-notifier on HE suites')
+    # Check that traps still logged, this will execute after a while since traps are recieved after a while
+    ansible_engine.shell('grep USER_ADD_TAG /var/log/snmptrapd.log | grep notifiertag')
 
 
 @order_by(_TEST_LIST)

--- a/common/deploy-scripts/setup_engine.sh
+++ b/common/deploy-scripts/setup_engine.sh
@@ -67,6 +67,13 @@ EOF
 
 cp /usr/share/doc/ovirt-engine/mibs/* /usr/share/snmp/mibs
 
+# We have to set DAYS_TO_SEND_ON_STARTUP to 1 because its default value is 0
+# it means that it will not send any old events, a race between the service start and
+# the new tag added above will cause that this event will not processed.
+echo "DAYS_TO_SEND_ON_STARTUP=1" >  /etc/ovirt-engine/notifier/notifier.conf.d/30-ovirt-engine-notifier.conf
+chown ovirt:ovirt /etc/ovirt-engine/notifier/notifier.conf.d/30-ovirt-engine-notifier.conf
+
+
 systemctl start snmpd
 systemctl start snmptrapd
 # new user created in net-snmp/snmpd*.conf are available only after services are restarted


### PR DESCRIPTION
This patch verifies that SNMP traps are still working after ovirt-engine-notifier and snmptrapd services are restarted.

First the services are restarted, then a new tag "notifiertag" is added to the system, finally we check that a trap generated on the new tag created is logged to snmptrapd.log

We have to set the configuration value DAYS_TO_SEND_ON_STARTUP to 1 in engine setup because its default value is 0, it means that it will not send any old events, a race between the service start and the new "notifiertag" tag will cause that this event will not be processed.

This patch was tested on upstream (el8) and downstream (rhel8)

Signed-off-by: Eli Mesika <emesika@redhat.com>