### PR TITLE
lagofy: use el9stream-engine-installed

### DIFF
--- a/common/helpers/ost-images.sh
+++ b/common/helpers/ost-images.sh
@@ -25,9 +25,6 @@ OST_IMAGES_HE_INSTALLED=${OST_IMAGES_HE_INSTALLED:-${OST_IMAGES_DIR}/${OST_IMAGE
 OST_IMAGES_STORAGE_BASE=${OST_IMAGES_STORAGE_BASE:=${OST_IMAGES_DIR}/storage-base.qcow2}
 OST_IMAGES_SSH_KEY=${OST_IMAGES_SSH_KEY:-${OST_IMAGES_DIR}/${OST_IMAGES_DISTRO}_id_rsa}
 
-# FIXME: until we will build el9stream enigne image, we can use el8 engine with el9 hosts
-[[ "$OST_IMAGES_DISTRO" == "el9stream" ]] && OST_IMAGES_ENGINE_INSTALLED=${OST_IMAGES_ENGINE_INSTALLED/el9stream/el8stream}
-
 for i in OST_IMAGES_BASE OST_IMAGES_NODE OST_IMAGES_ENGINE_INSTALLED OST_IMAGES_HOST_INSTALLED OST_IMAGES_HE_INSTALLED OST_IMAGES_SSH_KEY; do
   [[ -r "${!i}" ]] || declare $i=/usr/share/ost-images/$(basename ${!i})
   echo "${i} ${!i} $(rpm -qf ${!i} 2>/dev/null)"


### PR DESCRIPTION
now that we build el9stream engine and have the corresponding image, we can
run el9stream runs with it
