### PR TITLE
UI tests: Make new template

### DIFF
--- a/basic-suite-master/test-scenarios/test_100_basic_ui_sanity.py
+++ b/basic-suite-master/test-scenarios/test_100_basic_ui_sanity.py
@@ -604,9 +604,8 @@ def test_make_template(
     vm_list_view = VmListView(ovirt_driver)
     vm_list_view.select_entity('vm1')
     template_dialog = vm_list_view.new_template()
-    template_dialog.set_name(template_name)
     save_screenshot('new-template-dialog')
-    template_dialog.ok()
+    template_dialog.set_name_and_ok(template_name)
 
     webadmin_menu = WebAdminLeftMenu(ovirt_driver)
     template_list_view = webadmin_menu.open_template_list_view()

--- a/ost_utils/selenium/page_objects/VmListView.py
+++ b/ost_utils/selenium/page_objects/VmListView.py
@@ -153,12 +153,12 @@ class NewTemplateDialog(Displayable):
     def get_displayable_name(self):
         return 'New template dialog'
 
-    def set_name(self, template_name):
+    def set_name_and_ok(self, template_name):
         name_element = self.ovirt_driver.find_element(By.ID, 'VmMakeTemplatePopupWidget_name')
-        self.ovirt_driver.create_action_chains().click(name_element).send_keys(template_name).perform()
-
-    def ok(self):
-        self.ovirt_driver.button_wait_and_click('OK')
+        ok_element = self.ovirt_driver.find_element(By.XPATH, '//button[text()="OK"]')
+        self.ovirt_driver.create_action_chains().click(name_element).send_keys(template_name).click(
+            ok_element
+        ).perform()
         self.wait_for_not_displayed()
 
     def _is_cluster_loaded(self):


### PR DESCRIPTION
The make new template was failing with the lates Selenium. This patch creates one action chain for setting the name and pressing OK button.