### PR TITLE
ovn: Reenable test on el9stream

### DIFF
--- a/basic-suite-master/test-scenarios/test_004_basic_sanity.py
+++ b/basic-suite-master/test-scenarios/test_004_basic_sanity.py
@@ -1413,8 +1413,6 @@ def test_next_run_unplug_cpu(engine_api):
 
 @order_by(_TEST_LIST)
 def test_hotplug_nic(assert_vm_is_alive, engine_api, vm0_fqdn_or_ip, ost_images_distro):
-    if ost_images_distro == "el9stream":
-        pytest.xfail("regression in libvirt, waiting for a fix")
     vms_service = engine_api.system_service().vms_service()
     vm = vms_service.list(search='name=%s' % VM0_NAME)[0]
     nics_service = vms_service.vm_service(vm.id).nics_service()

--- a/basic-suite-master/test-scenarios/test_098_ovirt_provider_ovn.py
+++ b/basic-suite-master/test-scenarios/test_098_ovirt_provider_ovn.py
@@ -367,9 +367,6 @@ def test_provider_configured(hosts_service, ost_dc_name):
 
 @versioning.require_version(4, 2)
 def test_use_ovn_provider(engine_api, engine_ip_url, engine_full_username, engine_password, ost_images_distro):
-    # https://bugzilla.redhat.com/2092856
-    if ost_images_distro == "el9stream":
-        pytest.xfail("regression in libvirt, waiting for a fix")
     engine = engine_api.system_service()
     provider_id = network_utils.get_default_ovn_provider_id(engine)
 


### PR DESCRIPTION
The bug mentioned in the comment has been fixed.

Signed-off-by: Marcin Sobczyk <msobczyk@redhat.com>
