### PR TITLE
selenium: Go back to 4.0.0

### DIFF
--- a/ost_utils/pytest/fixtures/selenium.py
+++ b/ost_utils/pytest/fixtures/selenium.py
@@ -65,7 +65,7 @@ def selenium_browser_name(selenium_browser_options):
 @pytest.fixture(scope="session")
 def selenium_browser_image(selenium_browser_name):
     # synchronize changes with https://github.com/oVirt/ost-images/blob/master/configs/storage/setup_selenium_grid.sh
-    return f"quay.io/ovirt/selenium-standalone-{selenium_browser_name}:4.4.0"
+    return f"quay.io/ovirt/selenium-standalone-{selenium_browser_name}:4.0.0"
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
The 4.4.0 Selenium version is more unstable than 4.0.0.

Signed-off-by: Marcin Sobczyk <msobczyk@redhat.com>
