### PR TITLE
Use `shadow_root` for ui-extensions modals

### DIFF
--- a/ost_utils/selenium/navigation/driver.py
+++ b/ost_utils/selenium/navigation/driver.py
@@ -101,23 +101,21 @@ class Driver:
                 "return arguments[0].shadowRoot.querySelector('.ui-extensions-plugin-root')", container
             )
 
-    def _find_dialog_root_now(self, modal_id: str, driver: WebDriver = None) -> WebElement:
-        _driver = driver if driver else self.__driver
+    def _find_dialog_root_now(self, modal_id: str) -> WebElement:
         try:
             # prefer the shadowDom version
-            shadow_host = _driver.find_element(By.ID, f'shadow-root-container-{modal_id}')
+            shadow_host = self.__driver.find_element(By.ID, f'shadow-root-container-{modal_id}')
             return self._access_shadow_root(shadow_host)
         except NoSuchElementException:
             # if not found, look for a normal modal
-            old_modal = _driver.find_element(By.ID, modal_id)
-            return old_modal
+            return self.__driver.find_element(By.ID, modal_id)
 
     def _find_dialog_root(self, modal_id: str, immediate: bool = True) -> WebElement:
         if immediate:
             return self._find_dialog_root_now(modal_id)
         else:
             dialog_root = WebDriverWait(self.__driver, timeout=assert_utils.SHORT_TIMEOUT).until(
-                lambda driver: self._find_dialog_root_now(modal_id, driver)
+                lambda driver: self._find_dialog_root_now(modal_id)
             )
             return dialog_root
 

--- a/ost_utils/selenium/page_objects/ClusterListView.py
+++ b/ost_utils/selenium/page_objects/ClusterListView.py
@@ -4,12 +4,10 @@
 #
 import logging
 
-from selenium.webdriver.common.by import By
 from .ClusterDetailView import ClusterDetailView
 from .ClusterDialog import ClusterDialog
-from .Displayable import Displayable
+from .ClusterUpgradeDialog import ClusterUpgradeDialog
 from .EntityListView import EntityListView
-from .EventsView import EventsView
 
 LOGGER = logging.getLogger(__name__)
 
@@ -53,41 +51,3 @@ class ClusterListView(EntityListView):
         upgrade_dialog = ClusterUpgradeDialog(self.ovirt_driver)
         upgrade_dialog.wait_for_displayed()
         return upgrade_dialog
-
-
-class ClusterUpgradeDialog(Displayable):
-    def __init__(self, ovirt_driver):
-        super(ClusterUpgradeDialog, self).__init__(ovirt_driver)
-
-    def is_displayed(self):
-        modal_text = self.ovirt_driver.find_element(By.ID, 'cluster-upgrade-modal').text
-        return 'Loading Cluster Data' not in modal_text
-
-    def get_displayable_name(self):
-        return 'Upgrade cluster'
-
-    def toggle_check_all_hosts(self):
-        self.ovirt_driver.xpath_wait_and_click('Select all hosts is not clickable', '//input[@name="check-all"]')
-
-    def toggle_check_for_upgrade(self):
-        self.ovirt_driver.xpath_wait_and_click(
-            'Check for upgrade is not clickable', '//input[@id="upgrade-options-check-upgrade"]'
-        )
-
-    def toggle_reboot_hosts(self):
-        self.ovirt_driver.xpath_wait_and_click(
-            'Reboot hosts is not clickable', '//input[@id="upgrade-options-reboot-after"]'
-        )
-
-    def next(self):
-        self.ovirt_driver.xpath_wait_and_click('Next is not clickable', '//button[text()="Next"]')
-
-    def upgrade(self):
-        self.ovirt_driver.xpath_wait_and_click('Upgrade is not clickable', '//footer/button[text()="Upgrade"]')
-
-    def go_to_event_log(self):
-        self.ovirt_driver.xpath_wait_and_click('Go to events is not clickable', '//button[text()="Go to Event Log"]')
-
-        events_view = EventsView(self.ovirt_driver)
-        events_view.wait_for_displayed()
-        return events_view

--- a/ost_utils/selenium/page_objects/ClusterUpgradeDialog.py
+++ b/ost_utils/selenium/page_objects/ClusterUpgradeDialog.py
@@ -17,62 +17,70 @@ class ClusterUpgradeDialog(Displayable):
         super(ClusterUpgradeDialog, self).__init__(ovirt_driver)
 
     def is_displayed(self):
-        dialog = self.ovirt_driver.find_dialog_root('cluster-upgrade-modal', True)
-        modal_text = dialog.find_element(By.ID, 'cluster-upgrade-modal').text
+        modal_text = self.ovirt_driver.find_element(
+            ui_extension_modal_id='cluster-upgrade-modal',
+            by=By.ID,
+            value='cluster-upgrade-modal',
+        ).text
         return 'Loading Cluster Data' not in modal_text
 
     def get_displayable_name(self):
         return 'Upgrade cluster'
 
     def toggle_check_all_hosts(self):
-        check_all = self.ovirt_driver.find_dialog_element(
-            'cluster-upgrade-modal',
+        check_all = self.ovirt_driver.find_element(
+            ui_extension_modal_id='cluster-upgrade-modal',
+            by=By.CSS_SELECTOR,
+            value='input[name="check-all"]',
             message='Select all hosts is not clickable',
-            locator=(By.CSS_SELECTOR, 'input[name="check-all"]'),
-            waitCondition=lambda el: el.is_displayed() and el.is_enabled(),
         )
         check_all.click()
 
     def toggle_check_for_upgrade(self):
-        check_upgrade = self.ovirt_driver.find_dialog_element(
-            'cluster-upgrade-modal',
+        check_upgrade = self.ovirt_driver.find_element(
+            ui_extension_modal_id='cluster-upgrade-modal',
+            by=By.ID,
+            value='upgrade-options-check-upgrade',
             message='Check for upgrade is not clickable',
-            locator=(By.ID, 'upgrade-options-check-upgrade'),
-            waitCondition=lambda el: el.is_displayed() and el.is_enabled(),
         )
         check_upgrade.click()
 
     def toggle_reboot_hosts(self):
-        reboot_hosts = self.ovirt_driver.find_dialog_element(
-            'cluster-upgrade-modal',
+        reboot_hosts = self.ovirt_driver.find_element(
+            ui_extension_modal_id='cluster-upgrade-modal',
+            by=By.ID,
+            value='upgrade-options-reboot-after',
             message='Reboot hosts is not clickable',
-            locator=(By.ID, 'upgrade-options-reboot-after'),
-            waitCondition=lambda el: el.is_displayed() and el.is_enabled(),
         )
         reboot_hosts.click()
 
     def next(self):
-        dialog = self.ovirt_driver.find_dialog_root('cluster-upgrade-modal')
-        next_button = next(
-            (b for b in dialog.find_elements(By.CSS_SELECTOR, 'footer>button.pf-m-primary') if "Next" in b.text), None
+        modal_buttons = self.ovirt_driver.find_elements(
+            ui_extension_modal_id='cluster-upgrade-modal',
+            by=By.CSS_SELECTOR,
+            value='footer>button.pf-m-primary',
         )
+        next_button = next((b for b in modal_buttons if "Next" in b.text), None)
         assert next_button is not None
         next_button.click()
 
     def upgrade(self):
-        dialog = self.ovirt_driver.find_dialog_root('cluster-upgrade-modal')
-        upgrade_button = next(
-            (b for b in dialog.find_elements(By.CSS_SELECTOR, 'footer>button.pf-m-primary') if "Upgrade" in b.text),
-            None,
+        modal_buttons = self.ovirt_driver.find_elements(
+            ui_extension_modal_id='cluster-upgrade-modal',
+            by=By.CSS_SELECTOR,
+            value='footer>button.pf-m-primary',
         )
+        upgrade_button = next((b for b in modal_buttons if "Upgrade" in b.text), None)
         assert upgrade_button is not None
         upgrade_button.click()
 
     def go_to_event_log(self):
-        dialog = self.ovirt_driver.find_dialog_root('cluster-upgrade-modal')
-        goto_button = next(
-            (b for b in dialog.find_elements(By.CSS_SELECTOR, 'button') if "Go to Event Log" in b.text), None
+        modal_buttons = self.ovirt_driver.find_elements(
+            ui_extension_modal_id='cluster-upgrade-modal',
+            by=By.CSS_SELECTOR,
+            value='button',
         )
+        goto_button = next((b for b in modal_buttons if "Go to Event Log" in b.text), None)
         assert goto_button is not None
         goto_button.click()
 

--- a/ost_utils/selenium/page_objects/ClusterUpgradeDialog.py
+++ b/ost_utils/selenium/page_objects/ClusterUpgradeDialog.py
@@ -32,7 +32,6 @@ class ClusterUpgradeDialog(Displayable):
             ui_extension_modal_id='cluster-upgrade-modal',
             by=By.CSS_SELECTOR,
             value='input[name="check-all"]',
-            message='Select all hosts is not clickable',
         )
         check_all.click()
 
@@ -41,7 +40,6 @@ class ClusterUpgradeDialog(Displayable):
             ui_extension_modal_id='cluster-upgrade-modal',
             by=By.ID,
             value='upgrade-options-check-upgrade',
-            message='Check for upgrade is not clickable',
         )
         check_upgrade.click()
 
@@ -50,7 +48,6 @@ class ClusterUpgradeDialog(Displayable):
             ui_extension_modal_id='cluster-upgrade-modal',
             by=By.ID,
             value='upgrade-options-reboot-after',
-            message='Reboot hosts is not clickable',
         )
         reboot_hosts.click()
 

--- a/ost_utils/selenium/page_objects/ClusterUpgradeDialog.py
+++ b/ost_utils/selenium/page_objects/ClusterUpgradeDialog.py
@@ -1,0 +1,81 @@
+#
+# Copyright oVirt Authors
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+import logging
+
+from selenium.webdriver.common.by import By
+
+from .Displayable import Displayable
+from .EventsView import EventsView
+
+LOGGER = logging.getLogger(__name__)
+
+
+class ClusterUpgradeDialog(Displayable):
+    def __init__(self, ovirt_driver):
+        super(ClusterUpgradeDialog, self).__init__(ovirt_driver)
+
+    def is_displayed(self):
+        dialog = self.ovirt_driver.find_dialog_root('cluster-upgrade-modal', True)
+        modal_text = dialog.find_element(By.ID, 'cluster-upgrade-modal').text
+        return 'Loading Cluster Data' not in modal_text
+
+    def get_displayable_name(self):
+        return 'Upgrade cluster'
+
+    def toggle_check_all_hosts(self):
+        check_all = self.ovirt_driver.find_dialog_element(
+            'cluster-upgrade-modal',
+            message='Select all hosts is not clickable',
+            locator=(By.CSS_SELECTOR, 'input[name="check-all"]'),
+            waitCondition=lambda el: el.is_displayed() and el.is_enabled(),
+        )
+        check_all.click()
+
+    def toggle_check_for_upgrade(self):
+        check_upgrade = self.ovirt_driver.find_dialog_element(
+            'cluster-upgrade-modal',
+            message='Check for upgrade is not clickable',
+            locator=(By.ID, 'upgrade-options-check-upgrade'),
+            waitCondition=lambda el: el.is_displayed() and el.is_enabled(),
+        )
+        check_upgrade.click()
+
+    def toggle_reboot_hosts(self):
+        reboot_hosts = self.ovirt_driver.find_dialog_element(
+            'cluster-upgrade-modal',
+            message='Reboot hosts is not clickable',
+            locator=(By.ID, 'upgrade-options-reboot-after'),
+            waitCondition=lambda el: el.is_displayed() and el.is_enabled(),
+        )
+        reboot_hosts.click()
+
+    def next(self):
+        dialog = self.ovirt_driver.find_dialog_root('cluster-upgrade-modal')
+        next_button = next(
+            (b for b in dialog.find_elements(By.CSS_SELECTOR, 'footer>button.pf-m-primary') if "Next" in b.text), None
+        )
+        assert next_button is not None
+        next_button.click()
+
+    def upgrade(self):
+        dialog = self.ovirt_driver.find_dialog_root('cluster-upgrade-modal')
+        upgrade_button = next(
+            (b for b in dialog.find_elements(By.CSS_SELECTOR, 'footer>button.pf-m-primary') if "Upgrade" in b.text),
+            None,
+        )
+        assert upgrade_button is not None
+        upgrade_button.click()
+
+    def go_to_event_log(self):
+        dialog = self.ovirt_driver.find_dialog_root('cluster-upgrade-modal')
+        goto_button = next(
+            (b for b in dialog.find_elements(By.CSS_SELECTOR, 'button') if "Go to Event Log" in b.text), None
+        )
+        assert goto_button is not None
+        goto_button.click()
+
+        events_view = EventsView(self.ovirt_driver)
+        events_view.wait_for_displayed()
+        return events_view

--- a/ost_utils/selenium/page_objects/VmDetailView.py
+++ b/ost_utils/selenium/page_objects/VmDetailView.py
@@ -72,18 +72,21 @@ class VmVgpuDialog(Displayable):
         super(VmVgpuDialog, self).__init__(ovirt_driver)
 
     def is_displayed(self):
-        dialog = self.ovirt_driver.find_dialog_root('vm-manage-gpu-modal', True)
-        modal_text = dialog.find_element(By.ID, 'vm-manage-gpu-modal').text
+        modal_text = self.ovirt_driver.find_element(
+            ui_extension_modal_id='vm-manage-gpu-modal',
+            by=By.ID,
+            value='vm-manage-gpu-modal',
+        ).text
         return 'Select vGPU type' in modal_text
 
     def get_displayable_name(self):
         return 'Manage vGPU dialog'
 
     def get_title(self):
-        dialog = self.ovirt_driver.find_dialog_root('vm-manage-gpu-modal')
-        return dialog.find_element(
-            By.CSS_SELECTOR,
-            'h4.modal-title,h1.pf-c-title,h1.pf-c-modal-box__title',
+        return self.ovirt_driver.find_element(
+            ui_extension_modal_id='vm-manage-gpu-modal',
+            by=By.CSS_SELECTOR,
+            value='h4.modal-title,h1.pf-c-title,h1.pf-c-modal-box__title',
         ).text
 
     def get_row_data(self, row_index):
@@ -91,8 +94,9 @@ class VmVgpuDialog(Displayable):
         row_index is the 1-based indexed row to return
         """
 
-        dialog = self.ovirt_driver.find_dialog_root('vm-manage-gpu-modal')
-        tbodys = dialog.find_elements(By.CSS_SELECTOR, 'table.vgpu-table > tbody')
+        tbodys = self.ovirt_driver.find_elements(
+            ui_extension_modal_id='vm-manage-gpu-modal', by=By.CSS_SELECTOR, value='table.vgpu-table > tbody'
+        )
 
         # the list is 0-base but the index is 1-based so adjust
         row = tbodys[row_index - 1]
@@ -101,11 +105,13 @@ class VmVgpuDialog(Displayable):
 
     def cancel(self):
         LOGGER.debug('Cancel vGPU dialog')
-        dialog = self.ovirt_driver.find_dialog_root('vm-manage-gpu-modal')
-        cancel_button = next(
-            (b for b in dialog.find_elements(By.CSS_SELECTOR, 'footer>button') if "Cancel" in b.text),
-            None,
+
+        modal_buttons = self.ovirt_driver.find_elements(
+            ui_extension_modal_id='vm-manage-gpu-modal',
+            by=By.CSS_SELECTOR,
+            value='footer>button',
         )
+        cancel_button = next((b for b in modal_buttons if "Cancel" in b.text), None)
         assert cancel_button is not None
         cancel_button.click()
 

--- a/ost_utils/selenium/page_objects/WithOvirtDriver.py
+++ b/ost_utils/selenium/page_objects/WithOvirtDriver.py
@@ -2,7 +2,10 @@
 # Copyright oVirt Authors
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
+from ost_utils.selenium.navigation.driver import Driver
+
+
 class WithOvirtDriver:
-    def __init__(self, ovirt_driver):
+    def __init__(self, ovirt_driver: Driver):
         super(WithOvirtDriver, self).__init__()
         self.ovirt_driver = ovirt_driver


### PR DESCRIPTION
To accommodate PR https://github.com/oVirt/ovirt-engine-ui-extensions/pull/73 that uses shadow DOM to render modals from ovirt-engine-ui-extensions, adjust the selenium tests to use the `shadow_root` when necessary.  Querying elements from the base document do not recurse into shadow-roots.  See https://github.com/oVirt/ovirt-engine-ui-extensions/pull/73#issuecomment-1259760170 for more explanation.

Some more info on shadow dom in selenium: https://titusfortner.com/2021/11/22/shadow-dom-selenium.html

The changes will be backwards compatible with non shadow dom modals.

Change details:

`driver`
  - add type info so Intellisense works within the class
  - add `find_dialog_root`, `find_dialog_element` and related functions to more easily handle testing of dialogs/modals/popups
  - enhance `find_element` and `find_elements` functions to be usable against the shadow dom ui-extensions modals
  - maintain backward compatibility for old ui-extensions dialogs
  - Chrome and Firefox currently have different handling requirements for shadow DOM components.  The difference is accounted for in function `_access_shadow_root`.

`ClusterListView`
  - split out ClusterUpgradeDialog to a seperate file

`ClusterUpgradeDialog`
  - use the ui-extensions enhanced `find_element` and `find_elements` functions to handle both shadowRoot and normal DOM structures

`VmVgpuDialog`
  - use the ui-extensions enhanced `find_element` and `find_elements` functions to handle both shadowRoot and normal DOM structures

`WithOvirtDriver`
  - add type info so Intellisense works in subclasses

