### PR TITLE
enable sysstat on el9stream appliance

### DIFF
--- a/common/deploy-scripts/setup_first_he_host.sh
+++ b/common/deploy-scripts/setup_first_he_host.sh
@@ -89,6 +89,18 @@ copy_dependencies() {
     dest: /var/tmp/lm_sensors.rpm
   with_fileglob:
     - "/var/tmp/lm_sensors-*"
+- name: Copy sysstat dependencies to HE VM
+  copy:
+    src: "{{ item }}"
+    dest: /var/tmp/pcp_conf.rpm
+  with_fileglob:
+    - "/var/tmp/pcp-conf-*"
+- name: Copy sysstat dependencies to HE VM
+  copy:
+    src: "{{ item }}"
+    dest: /var/tmp/pcp_libs.rpm
+  with_fileglob:
+    - "/var/tmp/pcp-libs-*"
 - name: Copy OpenSCAP profile name
   copy:
     src: /root/ost_images_openscap_profile

--- a/he-basic-suite-master/test-scenarios/test_001_he_deploy.py
+++ b/he-basic-suite-master/test-scenarios/test_001_he_deploy.py
@@ -94,11 +94,9 @@ def test_set_global_maintenance(ansible_host0):
 
 
 def test_install_sar_collection(root_dir, ansible_engine, ost_images_distro):
-    # TODO: Remove when we have an el9stream-based HE available
-    if ost_images_distro == "el9stream":
-        pytest.skip("el9stream packages are not installable on el8stream HE")
-
     ansible_engine.dnf(name='/var/tmp/lm_sensors.rpm', disable_gpg_check='yes')
+    ansible_engine.dnf(name='/var/tmp/pcp_conf.rpm', disable_gpg_check='yes')
+    ansible_engine.dnf(name='/var/tmp/pcp_libs.rpm', disable_gpg_check='yes')
     ansible_engine.dnf(name='/var/tmp/sysstat.rpm', disable_gpg_check='yes')
     ansible_engine.file(
         path='/etc/systemd/system/sysstat-collect.timer.d',


### PR DESCRIPTION
with el9-based engine we no longer need the workaround
