### PR TITLE
Fix selenium timeouts

### DIFF
--- a/basic-suite-master/test-scenarios/test_100_basic_ui_sanity.py
+++ b/basic-suite-master/test-scenarios/test_100_basic_ui_sanity.py
@@ -18,6 +18,7 @@ import time
 import ovirtsdk4.types as types
 import pytest
 import requests
+import selenium.webdriver.remote.remote_connection
 
 from selenium import webdriver
 from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
@@ -47,6 +48,18 @@ from ost_utils.shell import ShellError
 from ost_utils.shell import shell
 
 LOGGER = logging.getLogger(__name__)
+
+
+# This is a variable that describes how long the client code will wait for a
+# response from the server. The default timeout is 5 mins. On the server side
+# there's another timeout variable that decides when to kill an inactive client
+# session. The default for this one is 3 mins. This makes the client-side
+# default unreasonable - before it realizes it should retry a request to the
+# server, its session will already be killed. Let's use a value of 30 secs
+# instead. Unfortunately the architecture of Selenium's code doesn't allow
+# changing it in an easy way - it enforces inheritance. This hack is ugly, but
+# should work for us.
+selenium.webdriver.remote.remote_connection.RemoteConnection._timeout = 30  # seconds
 
 
 @pytest.fixture(scope="module", autouse=True)


### PR DESCRIPTION
From time to time Selenium server hangs indefinitely on http requests
made by client. Looking at the logs it seems that the netty code sees
the http request, but somehow it never reaches the code that handles the
response.

The client side blocks until it gets a response from the server.
The timeout for this path seems to be 5 mins. On the server side
however, the timeout for an inactive session to be killed is set
to 3 mins by default. That combination creates an undesired effect -
before the client realizes that the http request may have been stuck for
too long, the server already kills its session.

This patch shortens the client timeout for waiting on http
responses to 30 secs. Unfortunately, with current client implementation
in Selenium library, it's not possible to change this value
through i.e. an '__init__' argument - it rather enforces subclassing.
Although ugly, changing the 'RemoteConnection._timeout' class member
directly works for us.

Furthermore, the recent client libraries does not seem to translate an
urllib3's 'ReadTimeoutError' exception to Selenium's 'TimeoutException'
This is why we also add it to a list of handled/ignored exceptions
in a couple of places.

Signed-off-by: Marcin Sobczyk <msobczyk@redhat.com>
