### PR TITLE
network: xfail on el9 due to no connectivity

### DIFF
--- a/network-suite-master/test-scenarios/ovn-provider/test_ovn_provider.py
+++ b/network-suite-master/test-scenarios/ovn-provider/test_ovn_provider.py
@@ -48,7 +48,11 @@ def test_ovn_provider_create_scenario(openstack_client_config, af, ansible_priva
     _test_ovn_provider(scenario[af.family], ansible_private_dir)
 
 
-def test_validate_ovn_provider_connectivity(default_ovn_provider_client, host_0, host_1, ovn_networks, af):
+def test_validate_ovn_provider_connectivity(
+    default_ovn_provider_client, host_0, host_1, ovn_networks, af, ost_images_distro, request
+):
+    if ost_images_distro == "el9stream":
+        request.node.add_marker(pytest.mark.xfail(reason="BZ 2144834", strict=True))
     net10, net11, net14 = ovn_networks
     ssh0 = sshlib.Node(host_0.address, host_0.root_password)
     ssh1 = sshlib.Node(host_1.address, host_1.root_password)

--- a/network-suite-master/test-scenarios/ovs/test_ovn_physnet.py
+++ b/network-suite-master/test-scenarios/ovs/test_ovn_physnet.py
@@ -122,8 +122,10 @@ def test_vnic_cannot_connect_physical_network(vm_in_ovs_cluster_down, ovirtmgmt_
 
 @suite.xfail_suite_43('BZ 1817589')
 def test_connect_vm_to_external_physnet(
-    system, ovs_cluster, ssh_host_not_in_ovs_cluster, vm_in_ovn_network_up, target, af
+    system, ovs_cluster, ssh_host_not_in_ovs_cluster, vm_in_ovn_network_up, target, af, ost_images_distro, request
 ):
+    if ost_images_distro == "el9stream":
+        request.node.add_marker(pytest.mark.xfail(reason="BZ 2144834", strict=True))
     syncutil.sync(
         exec_func=ssh_host_not_in_ovs_cluster.ping_successful,
         exec_func_args=(target, af.version, _max_icmp_data_size(af.family)),
@@ -133,8 +135,18 @@ def test_connect_vm_to_external_physnet(
 
 @suite.xfail_suite_43('BZ 1817589')
 def test_max_mtu_size(
-    system, ovs_cluster, ssh_host_not_in_ovs_cluster, ovn_physnet_small_mtu, vm_in_ovn_network_up, target, af
+    system,
+    ovs_cluster,
+    ssh_host_not_in_ovs_cluster,
+    ovn_physnet_small_mtu,
+    vm_in_ovn_network_up,
+    target,
+    af,
+    ost_images_distro,
+    request,
 ):
+    if ost_images_distro == "el9stream":
+        request.node.add_marker(pytest.mark.xfail(reason="BZ 2144834", strict=True))
     syncutil.sync(
         exec_func=ssh_host_not_in_ovs_cluster.ping_successful,
         exec_func_args=(target, af.version, _max_icmp_data_size(af.family)),
@@ -163,7 +175,11 @@ def test_security_groups_allow_icmp(
     target,
     af,
     ansible_private_dir,
+    ost_images_distro,
+    request,
 ):
+    if ost_images_distro == "el9stream":
+        request.node.add_marker(pytest.mark.xfail(reason="BZ 2144834", strict=True))
     syncutil.sync(
         exec_func=ssh_host_not_in_ovs_cluster.ping_successful,
         exec_func_args=(target, af.version, _max_icmp_data_size(af.family)),


### PR DESCRIPTION
OVN connectivity does not work on el9.

Change-Id: I692b4e21b4a37e6164f06cae74e92b3f18e75cc7
Signed-off-by: Eitan Raviv <eraviv@redhat.com>