### PR TITLE
Downgrade openjdk to workaround keycloak setup issue

### DIFF
--- a/common/deploy-scripts/setup_first_he_host.sh
+++ b/common/deploy-scripts/setup_first_he_host.sh
@@ -56,6 +56,8 @@ dnf_update() {
     line: |
       proxy=socks5://localhost:1234
       ip_resolve=4
+- name: Downgrade java-11-openjdk-headless to workaround keycloak setup issue
+  shell: dnf downgrade -y java-11-openjdk-headless-11.0.15.0.10-3.el8 || true
 - name: Remove all repositories
   file:
     path: /etc/yum.repos.d

--- a/ost_utils/pytest/fixtures/deployment.py
+++ b/ost_utils/pytest/fixtures/deployment.py
@@ -137,6 +137,9 @@ def deploy(
             ssh_key_file,
         )
 
+    # Downgrade openjdk to workaround keycloak setup issue
+    ansible_all.shell('dnf downgrade -y java-11-openjdk-headless-11.0.15.0.10-3.el8 || true')
+
     # disable all repos
     LOGGER.info("Disable default repositories")
     package_mgmt.disable_all_repos(ansible_all)


### PR DESCRIPTION
Downgrade java-11-openjdk-headless to 11.0.15.0.10-3 to workaround
following error during keycloak setup:

  Failed to load truststore: /etc/pki/ovirt-engine/.truststore

Signed-off-by: Martin Perina <mperina@redhat.com>
