### PR TITLE
basic: adjust memory sizes for VMs

### DIFF
--- a/basic-suite-master/test-scenarios/test_002_bootstrap.py
+++ b/basic-suite-master/test-scenarios/test_002_bootstrap.py
@@ -1271,17 +1271,15 @@ def test_add_blank_vms(engine_api, ost_cluster_name):
     )
 
     vm_params.name = BACKUP_VM_NAME
-    vm_params.memory = 160 * MB
-    vm_params.memory_policy.guaranteed = 106 * MB
+    vm_params.memory = 512 * MB
+    vm_params.memory_policy.guaranteed = 160 * MB
     vms_service.add(vm_params)
     backup_vm_service = test_utils.get_vm_service(engine, BACKUP_VM_NAME)
 
     vm_params.name = VM0_NAME
-    least_hotplug_increment = 256 * MB
-    required_memory = 160 * MB
-    vm_params.memory = required_memory
-    vm_params.memory_policy.guaranteed = required_memory
-    vm_params.memory_policy.max = required_memory + least_hotplug_increment
+    vm_params.memory = 512 * MB
+    vm_params.memory_policy.guaranteed = 160 * MB
+    vm_params.memory_policy.max = 768 * MB  # defined mem + hotplug of 256MB in test_hotplug_memory
 
     vms_service.add(vm_params)
     vm0_vm_service = test_utils.get_vm_service(engine, VM0_NAME)
@@ -1347,10 +1345,10 @@ def test_add_blank_high_perf_vm2(engine_api, ost_dc_name, ost_cluster_name):
             ),
             memory_policy=sdk4.types.MemoryPolicy(
                 ballooning=False,
-                guaranteed=106 * MB,
-                max=256 * MB,
+                guaranteed=160 * MB,
+                max=512 * MB,
             ),
-            memory=160 * MB,
+            memory=512 * MB,
             high_availability=sdk4.types.HighAvailability(
                 enabled=True,
                 priority=100,

--- a/basic-suite-master/test-scenarios/test_004_basic_sanity.py
+++ b/basic-suite-master/test-scenarios/test_004_basic_sanity.py
@@ -910,7 +910,7 @@ def test_add_vm1_from_template(engine_api, cirros_image_template_name, ost_clust
             )
         )
 
-    vm_memory = 128 * MB  # runs with 64 ok, but we need to do a hotplug later (64+256 is too much difference)
+    vm_memory = 512 * MB
     vms_service = engine.vms_service()
     vms_service.add(
         types.Vm(
@@ -926,8 +926,8 @@ def test_add_vm1_from_template(engine_api, cirros_image_template_name, ost_clust
             use_latest_template_version=True,
             stateless=True,
             memory_policy=types.MemoryPolicy(
-                guaranteed=vm_memory,  # with so little memory we don't want guaranteed to be any lower
-                ballooning=False,
+                guaranteed=160 * MB,
+                ballooning=True,
             ),
             os=types.OperatingSystem(
                 type='rhel_7x64',  # even though it's CirrOS we want to check a non-default OS type

--- a/common/init-configs/1_engine_2_hosts.json
+++ b/common/init-configs/1_engine_2_hosts.json
@@ -70,7 +70,7 @@
   },
   "host-0": {
     "template": "common/libvirt-templates/vm_template",
-    "memory": "1792",
+    "memory": "2560",
     "deploy-scripts": [
       "common/deploy-scripts/setup_host.sh"
     ],
@@ -85,7 +85,7 @@
   },
   "host-1": {
     "template": "common/libvirt-templates/vm_template",
-    "memory": "1792",
+    "memory": "2560",
     "deploy-scripts": [
       "common/deploy-scripts/setup_host.sh"
     ],


### PR DESCRIPTION
we seem to have frequent memory allocation issues with UEFI during
its initialization. Let's give VMs more memory without really increasing
guaranteed mem, so UEFI can take whatever it needs and it will get
ballooned anyway if the host doesn't have enough later on.
