### PR TITLE
Dump console and firmware logs for all VMs

### DIFF
--- a/common/deploy-scripts/setup_host.sh
+++ b/common/deploy-scripts/setup_host.sh
@@ -58,7 +58,16 @@ EOF
     sed -i "s/^#vnc_sasl =.*/vnc_sasl = 1/" /etc/libvirt/qemu.conf
 fi
 
-# Configure vdsm-hook-log-console to log the console of the hosted-engine VM
-echo 'log_console_vm_regexp=HostedEngine' > /etc/sysconfig/vdsm
+# Configure vdsm-hook-log-console and vdsm-hook-log-firmware for all VMs
+echo 'log_console=on' >> /etc/sysconfig/vdsm
+echo 'log_console_vm_regexp=*' >> /etc/sysconfig/vdsm
+echo 'log_firmware=on' >> /etc/sysconfig/vdsm
+echo 'log_firmware_vm_regexp=*' >> /etc/sysconfig/vdsm
+
+# Prepare directory for firmware log dump
+mkdir -p /var/log/qemu-firmware
+chown qemu /var/log/qemu-firmware
+chcon -t qemu_var_run_t /var/log/qemu-firmware
+chmod 700 /var/log/qemu-firmware
 
 coredump_kill


### PR DESCRIPTION
Problems with nested VMs' firmware are hard to debug. A dump of firmware
log is very helpful with that, so let's have it on by default in OST.

Initially the console logs were only set up for HE, but having them
for all the VMs helps a lot too.

Needs https://github.com/oVirt/ost-images/pull/91 to work properly.

Signed-off-by: Marcin Sobczyk <msobczyk@redhat.com>
