### PR TITLE
requirements.txt: use specific openstacksdk commit 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ requests
 selenium==4.4.3
 # network suite deps
 # TODO Use pip version once released openstacksdk>=0.62.0
-git+https://github.com/openstack/openstacksdk.git@master
+git+https://github.com/openstack/openstacksdk.git@44c5515
 # ost_utils
 paramiko
 PyYAML


### PR DESCRIPTION
Openstacksdk>=0.62.0 is now published on pypi. Use it going forward.

Change-Id: I26a094b522202ace8c5e0d30749571a46d5d25d9
Signed-off-by: Eitan Raviv <eraviv@redhat.com>