### PR TITLE
network: adjust memory sizes for VMs

### DIFF
--- a/network-suite-master/ovirtlib/virtlib.py
+++ b/network-suite-master/ovirtlib/virtlib.py
@@ -188,15 +188,15 @@ class Vm(SDKRootEntity):
         :type template: string
         :type stateless: boolean
         """
-        MB256 = 256 * 2 ** 20
+        MB512 = 512 * 2 ** 20
 
         sdk_type = types.Vm(
             name=vm_name,
             cluster=cluster.get_sdk_type(),
             template=types.Template(name=template),
             stateless=stateless,
-            memory=MB256,
-            memory_policy=types.MemoryPolicy(guaranteed=MB256 // 2),
+            memory=MB512,
+            memory_policy=types.MemoryPolicy(guaranteed=MB512 // 2),
             console=types.Console(enabled=True),
         )
         self._create_sdk_entity(sdk_type)


### PR DESCRIPTION
Adjust VM memory size in network suite to align with adjustments in basic suite [1].

[1] https://github.com/oVirt/ovirt-system-tests/
    commit/1d0bf8cfc7e6678f19e85089e58790ad35b3c53c

Change-Id: I70ffe291c807c809a482dd29f9bfdb5a2235dfbc
Signed-off-by: Eitan Raviv <eraviv@redhat.com>