### PR TITLE
ansible: Start image_template from engine

### DIFF
--- a/basic-suite-master/test-scenarios/test_002_bootstrap.py
+++ b/basic-suite-master/test-scenarios/test_002_bootstrap.py
@@ -1765,7 +1765,6 @@ def test_create_cirros_template(
     engine_password,
     ost_cluster_name,
     cirros_image_template_name,
-    engine_hostname,
     ssh_key_file,
     master_storage_domain_name,
 ):
@@ -1773,7 +1772,6 @@ def test_create_cirros_template(
         ansible_engine,
         ansible_inventory,
         ssh_key_file,
-        engine_hostname,
         engine_fqdn=engine_fqdn,
         engine_user=engine_full_username,
         engine_password=engine_password,

--- a/ost_utils/ansible/collection.py
+++ b/ost_utils/ansible/collection.py
@@ -106,10 +106,9 @@ def image_template(
     ansible_engine,
     ansible_inventory,
     ssh_key_path,
-    engine_hostname,
     **kwargs,
 ):
-    playbook_yaml = _get_role_playbook('image_template', engine_hostname, **kwargs)
+    playbook_yaml = _get_role_playbook('image_template', 'localhost', **kwargs)
     _run_playbook(ansible_engine, playbook_yaml, ansible_inventory, ssh_key_path)
 
 


### PR DESCRIPTION
The image_template did not start the playbook from engine but from some
diffrent place. With this patch the playbook is copied to the engine and
started there.

