### PR TITLE
selenium: Create artifacts dir manually

### DIFF
--- a/ost_utils/pytest/fixtures/selenium.py
+++ b/ost_utils/pytest/fixtures/selenium.py
@@ -106,6 +106,7 @@ def selenium_browser(
     selenium_screen_height,
     selenium_screen_width,
 ):
+    ansible_storage.shell(f"mkdir -p {selenium_remote_artifacts_dir}")
     container_id = ansible_storage.shell(
         "podman run -d"
         f" -p {selenium_port}:{selenium_port}"


### PR DESCRIPTION
OST started complaining that `{selenium_remote_artifacts_dir}` doesn't exist. We never created it by ourselves, so it's probable some new podman version changed behavior in this regard.