### PR TITLE
docs: Fix GitHub job

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -81,6 +81,7 @@ commands =
     bash ./common/scripts/check_copyright_notices.sh
 
 [testenv:docs]
+basepython = python3.10
 passenv = *
 setenv =
     LC_ALL = C


### PR DESCRIPTION
'check-readthedocs' action uses 'ubuntu:latest' image underneath. This one has py3.10 installed, so let's change the job definition in tox.