### PR TITLE
selenium: Change permissions on artifacts dir

### DIFF
--- a/ost_utils/pytest/fixtures/selenium.py
+++ b/ost_utils/pytest/fixtures/selenium.py
@@ -106,7 +106,7 @@ def selenium_browser(
     selenium_screen_height,
     selenium_screen_width,
 ):
-    ansible_storage.shell(f"mkdir -p {selenium_remote_artifacts_dir}")
+    ansible_storage.shell(f"mkdir -m 777 -p {selenium_remote_artifacts_dir}")
     container_id = ansible_storage.shell(
         "podman run -d"
         f" -p {selenium_port}:{selenium_port}"


### PR DESCRIPTION
The directory is created with root:root and 755 permissions. Chrome container runs under 'seluser', so it's lacking write permissions.