### PR TITLE
Allow Grafana connecting to PostgreSQL

### DIFF
--- a/common/deploy-scripts/setup_engine.sh
+++ b/common/deploy-scripts/setup_engine.sh
@@ -83,3 +83,9 @@ systemctl restart snmptrapd
 systemctl enable snmpd
 systemctl enable snmptrapd
 
+# Allow Grafana to connect PostgreSQL data source to use ovirt_engine_history database
+# TODO Replace with proper fix in ovirt-dwh when grafana_can_tcp_connect_postgresql_port is added to grafana-selinux
+cat >> /tmp/grafana-postgresql-ds.cil << EOF
+(allow grafana_t postgresql_port_t (tcp_socket (name_connect)))
+EOF
+semodule -i /tmp/grafana-postgresql-ds.cil


### PR DESCRIPTION
Allows Grafana to connect to PostgreSQL datasource, for example
ovirt_engine_history database.

Signed-off-by: Martin Perina <mperina@redhat.com>
