### PR TITLE
run OST on el9stream by default

### DIFF
--- a/.github/workflows/ost.yaml
+++ b/.github/workflows/ost.yaml
@@ -23,7 +23,7 @@ on:
         type: string
       comment:
         required: true
-        default: "/ost basic-suite-master el8stream"
+        default: "/ost basic-suite-master el9stream"
         type: string
 
 jobs:


### PR DESCRIPTION
el8stream is not functional due to ansible breakage for a while, el9stream works fine.