### PR TITLE
Multiple custom repos + ost on ost PRs

### DIFF
--- a/.github/workflows/ost.yaml
+++ b/.github/workflows/ost.yaml
@@ -19,6 +19,7 @@ on:
   workflow_dispatch:
     inputs:
       pr_url:
+        description: "PR url(s - comma separated)"
         required: true
         type: string
       comment:
@@ -91,14 +92,21 @@ jobs:
             ${{ github.event.issue.url }}/comments \
             -d "{\"body\":\"${MSG}\"}"
 
-      - name: Run ${{ env.SUITE }} on ${{ env.DISTRO }}
+      - name: Run ${{ env.SUITE }} on ${{ env.DISTRO }} for [${{ env.PR_URL }}]
         id: run-tests
         continue-on-error: true
         run: |
           ./ost.sh destroy
           cat md-report.ini >> pytest.ini
           export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
-          /usr/bin/bash ost.sh run $SUITE $DISTRO --custom-repo $PR_URL
+
+          if [[ "$PR_URL" == *","* ]]; then
+            PR_URL=$(echo "$PR_URL" | sed 's/ //g')
+            PR_URL=$(echo "$PR_URL" | sed 's/,/ --custom-repo /g')
+          fi
+          PR_URL="--custom-repo $PR_URL"
+          
+          /usr/bin/bash ost.sh run $SUITE $DISTRO $PR_URL
           
       - name: Create artifacts archive
         run: tar -czf exported-artifacts.tar.gz exported-artifacts

--- a/.github/workflows/ost.yaml
+++ b/.github/workflows/ost.yaml
@@ -46,12 +46,6 @@ jobs:
           github.event.comment.author_association == 'COLLABORATOR')
       )
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          repository: oVirt/ovirt-system-tests
-          ref: master
-
       - name: Set environment variables
         env:
           PR_URL: "${{ github.event.issue.pull_request.url }}${{ inputs.pr_url }}"
@@ -62,12 +56,25 @@ jobs:
           SUITE=${SUITE:-basic-suite-master}
           DISTRO=${DISTRO:-el9stream}
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+          OST_REPO="ovirt/ovirt-system-tests"
+          OST_REF="master"
+          IFS=',' read -ra PR_URLS <<< "$PR_URL"
+          for url in "${PR_URLS[@]}"; do
+              if [[ "$url" == *"$OST_REPO"* ]]; then
+                  PR_NR=$(echo "$url" | grep -oP '(?<=/pull/)\d+')
+                  OST_REF=$(curl -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+                     -H "Accept: application/vnd.github+json" \
+                     $GITHUB_API_URL/repos/$OST_REPO/pulls/$PR_NR \
+                | jq -r '.head.ref')
+          fi
           
           echo "SUITE=$SUITE" >> $GITHUB_ENV
           echo "DISTRO=$DISTRO" >> $GITHUB_ENV
           echo "PR_URL=$PR_URL" >> $GITHUB_ENV
           echo "COMMENT=$COMMENT" >> $GITHUB_ENV 
           echo "RUN_URL=$RUN_URL" >> $GITHUB_ENV
+          echo "OST_REF=$OST_REF" >> $GITHUB_ENV
           
           echo "==== RUN PARAMS ========"
           echo "PR_URL: $PR_URL"
@@ -75,7 +82,13 @@ jobs:
           echo "SUITE: $SUITE"
           echo "DISTRO: $DISTRO"
           echo "========================"
-          
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          repository: oVirt/ovirt-system-tests
+          ref: ${{ env.OST_REF }}
+
       - name: Setup ost 
         run: /usr/bin/bash setup_for_ost.sh -y
       

--- a/ost_utils/deployment_utils/package_mgmt.py
+++ b/ost_utils/deployment_utils/package_mgmt.py
@@ -31,7 +31,13 @@ def expand_repos(custom_repos, working_dir, ost_images_distro):
     repo_urls = []
     for repo_url in custom_repos:
         if re.match(r"https://(www\.|api\.)?github.com/(repos/)?oVirt", repo_url):
-            repo_urls.append(expand_github_repo(repo_url, working_dir, ost_images_distro))
+            if 'ovirt-system-tests' in repo_url:
+                LOGGER.info(
+                    "Not expanding 'ovirt-system-tests', it is skipped",
+                    repo_url,
+                )
+            else:
+                repo_urls.append(expand_github_repo(repo_url, working_dir, ost_images_distro))
         else:
             repo_urls.append(repo_url)
     return repo_urls


### PR DESCRIPTION
- Allow to provide multiple pr urls (csv) to be able to test multiple PRs. OST already supported this by providing multiple `--custom-repo` flags
- Allow to run an OST suite with the code in a PR on ovirt-system-tests (code needs to be on a branch on oVirt org)