### PR TITLE
requirements: use master version of python-ovirt-engine-sdk4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # PIP requirements for OST
-ovirt-engine-sdk-python>=4.6.2
+./python-ovirt-engine-sdk4
 ansible-runner
 pytest==6.2.2
 # basic suite deps

--- a/setup_for_ost.sh
+++ b/setup_for_ost.sh
@@ -98,3 +98,9 @@ ansible-playbook \
     ${ANSIBLE_ASK_SUDO_PASS_FLAG} \
     ${ANSIBLE_EXTRA_VARS_FLAG} ${ANSIBLE_EXTRA_VARS_FILE} \
     common/setup/setup_playbook.yml
+
+# Download latest SDK
+git clone --depth=1 https://github.com/oVirt/python-ovirt-engine-sdk4.git
+cd python-ovirt-engine-sdk4
+sh .automation/generate-setup-files.sh
+cd ..


### PR DESCRIPTION
Use the master version of our Python SDK.
This makes it possible to run CI on new things added in the SDK.