### PR TITLE
fixtures: remove tinycore workaround

### DIFF
--- a/common/deploy-scripts/setup_first_he_host.sh
+++ b/common/deploy-scripts/setup_first_he_host.sh
@@ -78,7 +78,7 @@ copy_dependencies() {
 - name: Copy cirros image to HE VM
   copy:
     src: /usr/share/ovirt-system-tests/cirros.img
-    dest: /usr/share/ovirt-system-tests/cirros.img
+    dest: /usr/share/ovirt-system-tests/
 - name: Copy sysstat rpm package to HE VM
   copy:
     src: "{{ item }}"

--- a/common/deploy-scripts/setup_storage.sh
+++ b/common/deploy-scripts/setup_storage.sh
@@ -209,8 +209,8 @@ setup_lvm_filter() {
     cat > /etc/lvm/lvmlocal.conf <<EOC
 
 devices {
-        # Either sda or sdb devices can include VG, from which we slice out logical volumes
-        global_filter = [ "a|/dev/sda|", "a|/dev/sdb|", "r|.*|" ]
+        # Either sda/sdb/sdc devices can include VG, from which we slice out logical volumes
+        global_filter = [ "a|/dev/sda|", "a|/dev/sdb|", "a|/dev/sdc|", "r|.*|" ]
 }
 
 EOC

--- a/common/init-configs/1_engine_2_hosts.json
+++ b/common/init-configs/1_engine_2_hosts.json
@@ -95,7 +95,7 @@
       "host-1-eth2": { "template": "common/libvirt-templates/nic_template" },
       "host-1-eth3": { "template": "common/libvirt-templates/nic_template" }
     },
-    "root_disk_var": "OST_IMAGES_NODE",
+    "root_disk_var": "OST_IMAGES_HOST_INSTALLED",
     "disks": {}
   }
 }

--- a/common/init-configs/1_hosted_engine_2_hosts.json
+++ b/common/init-configs/1_hosted_engine_2_hosts.json
@@ -72,7 +72,7 @@
       "host-1": { "template": "common/libvirt-templates/nic_template" },
       "host-1-storage": { "template": "common/libvirt-templates/nic_template" }
     },
-    "root_disk_var": "OST_IMAGES_NODE",
+    "root_disk_var": "OST_IMAGES_HE_INSTALLED",
     "disks": {}
   }
 }

--- a/ost_utils/pytest/fixtures/deployment.py
+++ b/ost_utils/pytest/fixtures/deployment.py
@@ -96,7 +96,6 @@ def start_sshd_proxy(vms, host, root_dir, ssh_key_file):
 @pytest.fixture(scope="session", autouse=True)
 def deploy(
     ansible_all,
-    ansible_engine,
     ansible_hosts,
     deploy_scripts,
     deploy_hosted_engine,
@@ -156,11 +155,6 @@ def deploy(
         # check if packages from custom repos were used
         if not request.config.getoption('--skip-custom-repos-check') and not deploy_hosted_engine:
             package_mgmt.check_installed_packages(ansible_all)
-
-    # TODO: build the tinycore image into ost-images
-    ansible_engine.shell(
-        "curl -L -o /usr/share/ovirt-system-tests/cirros.img https://github.com/oVirt/ovirt-tinycore-linux/releases/download/v13.13/oVirtTinyCore64-13.12.qcow2"
-    )
 
     # report package versions
     LOGGER.info('oVirt packages used on VMs:')


### PR DESCRIPTION
We added the tinycore image in the ost-images.
Therefor the workaround within deployment can be removed.