### PR TITLE
system-tests: add NVMe-oF/TCP storage domain tests

### DIFF
--- a/ansible-suite-master/test-scenarios/test_002_ansible.py
+++ b/ansible-suite-master/test-scenarios/test_002_ansible.py
@@ -114,7 +114,16 @@ def test_ansible_run(
                     "lun_id": lun.get_uuids(sd_iscsi_ansible_host)[:2],
                 }
             },
+            "nvmeof": {
+                "nvmeof": {
+                    "nqn": lun.get_nvmeof_connection_info(sd_iscsi_ansible_host)["nqn"],
+                    "port": 4420,
+                    "address": sd_iscsi_host_ip,
+                    "lun_id": lun.get_nvmeof_uuids(sd_iscsi_ansible_host),
+                }
+            },
         },
+
         logical_networks=[
             {
                 "name": "Migration_Net",

--- a/basic-suite-master/test-scenarios/conftest.py
+++ b/basic-suite-master/test-scenarios/conftest.py
@@ -87,3 +87,13 @@ def sd_iscsi_ansible_host(
     ansible_storage,
 ):  # pylint: disable=function-redefined
     return ansible_storage
+
+
+@pytest.fixture(scope="session")
+def sd_nvmeof_host_ip(storage_ips_for_network, storage_network_name):
+    return storage_ips_for_network(storage_network_name)[0]
+
+
+@pytest.fixture(scope="session")
+def sd_nvmeof_ansible_host(ansible_storage):
+    return ansible_storage

--- a/basic-suite-master/test-scenarios/test_002_bootstrap.py
+++ b/basic-suite-master/test-scenarios/test_002_bootstrap.py
@@ -64,6 +64,10 @@ SD_ISCSI_PORT = 3260
 SD_ISCSI_NR_LUNS = 2
 DLUN_DISK_NAME = 'DirectLunDisk'
 
+SD_NVMEOF_TARGET = 'nqn.2014-07.org.ovirt:nvmeof-storage'
+SD_NVMEOF_PORT = 4420
+SD_NVMEOF_NR_LUNS = 1
+
 SD_ISO_NAME = 'iso'
 SD_ISO_PATH = '/exports/nfs/iso'
 
@@ -121,6 +125,7 @@ _TEST_LIST = [
     "test_verify_add_hosts",
     "test_add_nfs_master_storage_domain",
     "test_add_iscsi_master_storage_domain",
+    "test_add_nvmeof_master_storage_domain",
     "test_add_quota_storage_limits",
     "test_add_blank_vms",
     "test_add_direct_lun_vm0",
@@ -419,6 +424,26 @@ def sd_iscsi_host_luns(sd_iscsi_host_lun_uuids, sd_iscsi_host_ip, sd_iscsi_port,
     )
 
 
+@pytest.fixture
+def sd_nvmeof_connection_info(sd_nvmeof_ansible_host):
+    return lun.get_nvmeof_connection_info(sd_nvmeof_ansible_host)
+
+
+@pytest.fixture
+def sd_nvmeof_host_lun_uuids(sd_nvmeof_ansible_host):
+    return lun.get_nvmeof_uuids(sd_nvmeof_ansible_host)[:SD_NVMEOF_NR_LUNS]
+
+
+@pytest.fixture
+def sd_nvmeof_host_luns(sd_nvmeof_host_lun_uuids, sd_nvmeof_connection_info):
+    return lun.create_nvmeof_lun_sdk_entries(
+        sd_nvmeof_host_lun_uuids,
+        sd_nvmeof_connection_info['address'],
+        sd_nvmeof_connection_info['port'],
+        sd_nvmeof_connection_info['nqn'],
+    )
+
+
 @order_by(_TEST_LIST)
 def test_add_iscsi_master_storage_domain(
     master_storage_domain_type, engine_api, hosts_service, sd_iscsi_host_luns, ost_dc_name
@@ -435,6 +460,17 @@ def test_add_nfs_master_storage_domain(
     if master_storage_domain_type != 'nfs':
         pytest.skip('not using nfs')
     add_nfs_storage_domain(engine_api, hosts_service, sd_nfs_host_storage_name, ost_dc_name)
+
+
+@order_by(_TEST_LIST)
+def test_add_nvmeof_master_storage_domain(
+    master_storage_domain_type, engine_api, hosts_service, sd_nvmeof_host_luns, ost_dc_name
+):
+    if master_storage_domain_type != 'nvmeof':
+        pytest.skip('not using nvmeof')
+    add_nvmeof_storage_domain(
+        engine_api, hosts_service, sd_nvmeof_host_luns, ost_dc_name
+    )
 
 
 def add_nfs_storage_domain(engine_api, hosts_service, sd_nfs_host_storage_name, dc_name):
@@ -476,7 +512,7 @@ def test_add_secondary_storage_domains(
     sd_iscsi_host_luns,
     ost_dc_name,
 ):
-    if master_storage_domain_type == 'iscsi':
+    if master_storage_domain_type in ('iscsi', 'nvmeof'):
         vt = utils.VectorThread(
             [
                 functools.partial(
@@ -567,6 +603,30 @@ def add_iscsi_storage_domain(engine_api, hosts_service, luns, dc_name):
         storage_format=(sdk4.types.StorageFormat.V4 if v4_domain else sdk4.types.StorageFormat.V3),
         storage=sdk4.types.HostStorage(
             type=sdk4.types.StorageType.ISCSI,
+            override_luns=True,
+            volume_group=sdk4.types.VolumeGroup(logical_units=luns),
+        ),
+    )
+
+    domain.add(engine_api, p, dc_name)
+
+
+def add_nvmeof_storage_domain(engine_api, hosts_service, luns, dc_name):
+    v4_domain = versioning.cluster_version_ok(4, 1)
+    p = sdk4.types.StorageDomain(
+        name=constants.SD_NVMEOF_NAME,
+        description='NVMe-oF Storage Domain',
+        type=sdk4.types.StorageDomainType.DATA,
+        discard_after_delete=v4_domain,
+        data_center=sdk4.types.DataCenter(
+            name=dc_name,
+        ),
+        host=host_utils.random_up_host(hosts_service, dc_name),
+        storage_format=(
+            sdk4.types.StorageFormat.V4 if v4_domain else sdk4.types.StorageFormat.V3
+        ),
+        storage=sdk4.types.HostStorage(
+            type=sdk4.types.StorageType.NVMEOF,
             override_luns=True,
             volume_group=sdk4.types.VolumeGroup(logical_units=luns),
         ),

--- a/basic-suite-master/test-scenarios/test_002_bootstrap.py
+++ b/basic-suite-master/test-scenarios/test_002_bootstrap.py
@@ -510,6 +510,7 @@ def test_add_secondary_storage_domains(
     hosts_service,
     sd_nfs_host_storage_name,
     sd_iscsi_host_luns,
+    sd_nvmeof_host_luns,
     ost_dc_name,
 ):
     if master_storage_domain_type in ('iscsi', 'nvmeof'):
@@ -551,6 +552,13 @@ def test_add_secondary_storage_domains(
                     engine_api,
                     hosts_service,
                     sd_iscsi_host_luns,
+                    ost_dc_name,
+                ),
+                functools.partial(
+                    add_nvmeof_storage_domain,
+                    engine_api,
+                    hosts_service,
+                    sd_nvmeof_host_luns,
                     ost_dc_name,
                 ),
                 # 12/07/2017 commenting out iso domain creation until we know why it causing random failures

--- a/common/deploy-scripts/setup_host.sh
+++ b/common/deploy-scripts/setup_host.sh
@@ -39,6 +39,7 @@ sed -i 's/weekly/daily/' /etc/logrotate.d/libvirtd
 
 # Increase ISCSI timeouts and disable MD5 (FIPS), see setup_storage.sh
 rpm -q iscsi-initiator-utils || yum install -y iscsi-initiator-utils
+rpm -q nvme-cli || yum install -y nvme-cli
 sed -i 's/#node.session.auth.authmethod = CHAP/node.session.auth.authmethod = CHAP/g' /etc/iscsi/iscsid.conf
 sed -i 's/#node.session.auth.chap_algs =.*/node.session.auth.chap_algs = SHA3-256,SHA256/g' /etc/iscsi/iscsid.conf
 sed -i 's/node.conn\[0\].timeo.noop_out_timeout = .*/node.conn\[0\].timeo.noop_out_timeout = 30/g' /etc/iscsi/iscsid.conf

--- a/common/deploy-scripts/setup_storage.sh
+++ b/common/deploy-scripts/setup_storage.sh
@@ -2,6 +2,8 @@
 
 MAIN_NFS_DEV="disk/by-id/scsi-0QEMU_QEMU_HARDDISK_2"
 ISCSI_DEV="disk/by-id/scsi-0QEMU_QEMU_HARDDISK_3"
+NVMEOF_DEV="disk/by-id/scsi-0QEMU_QEMU_HARDDISK_4"
+NVMEOF_DEV2="disk/by-id/scsi-0QEMU_QEMU_HARDDISK_5"
 NUM_LUNS=5
 
 setup_device() {
@@ -205,6 +207,50 @@ EOC
     sed -i 's/^nsslapd-cache-autosize:.*/nsslapd-cache-autosize: 0/' /etc/dirsrv/slapd-lago/dse.ldif
 }
 
+setup_nvmeof() {
+    local nvmeof_dev=$1
+    NIC=enp2s0
+    IP=$(/sbin/ip -o addr show dev $NIC scope global | tac | awk '{split($4,a,"."); print a[1] "." a[2] "." a[3] "." a[4]}'| awk -F/ '{print $1; exit}')
+    SUBSYS_NQN="nqn.2014-07.org.ovirt:nvmeof-storage"
+
+    rpm -q nvme-cli || yum install -y nvme-cli
+
+    modprobe nvmet || true
+    modprobe nvmet-tcp || true
+
+    mkdir -p /sys/kernel/config/nvmet/subsystems/${SUBSYS_NQN}
+    echo 1 > /sys/kernel/config/nvmet/subsystems/${SUBSYS_NQN}/attr/allow_any_host
+
+    mkdir -p /sys/kernel/config/nvmet/subsystems/${SUBSYS_NQN}/namespaces/1
+    echo -n /dev/${nvmeof_dev} > /sys/kernel/config/nvmet/subsystems/${SUBSYS_NQN}/namespaces/1/device_path
+    echo 1 > /sys/kernel/config/nvmet/subsystems/${SUBSYS_NQN}/namespaces/1/enable
+
+    mkdir -p /sys/kernel/config/nvmet/ports/1
+    echo 4420 > /sys/kernel/config/nvmet/ports/1/addr_trsvcid
+    echo tcp > /sys/kernel/config/nvmet/ports/1/addr_trtype
+    echo ipv4 > /sys/kernel/config/nvmet/ports/1/addr_adrfam
+    echo ${IP} > /sys/kernel/config/nvmet/ports/1/addr_traddr
+
+    ln -sf /sys/kernel/config/nvmet/subsystems/${SUBSYS_NQN} /sys/kernel/config/nvmet/ports/1/subsystems/${SUBSYS_NQN}
+
+    echo "${SUBSYS_NQN} ${IP} 4420" > /root/nvmeof_connection.txt
+
+    nvme connect -t tcp -n ${SUBSYS_NQN} -a ${IP} -s 4420
+    sleep 2
+    /usr/sbin/udevadm settle
+    for dev in /dev/nvme*n*; do
+        [ -e "$dev" ] || continue
+        uuid=$(cat /sys/block/$(basename $dev)/uuid 2>/dev/null || echo "")
+        if [ -n "$uuid" ]; then
+            echo "$uuid" > /root/nvmeof_uuids.txt
+            break
+        fi
+    done
+    [[ -s /root/nvmeof_uuids.txt ]] || { echo "Could not discover NVMe-oF namespace UUID"; exit 1; }
+    nvme disconnect -n ${SUBSYS_NQN}
+}
+
+
 setup_lvm_filter() {
     cat > /etc/lvm/lvmlocal.conf <<EOC
 
@@ -243,6 +289,11 @@ main() {
     activate_nfs
     setup_lvm_filter
     setup_iscsi
+    if [ -e /dev/${NVMEOF_DEV2} ]; then
+        setup_nvmeof ${NVMEOF_DEV2}
+    elif [ -e /dev/${NVMEOF_DEV} ]; then
+        setup_nvmeof ${NVMEOF_DEV}
+    fi
     # TODO el9 doesn't have 389-ds (LDAP) configuration yet
     # [ "$(. /etc/os-release; echo ${VERSION_ID})" != "9" ] && setup_389ds
     coredump_kill

--- a/common/init-configs/1_engine_2_hosts.json
+++ b/common/init-configs/1_engine_2_hosts.json
@@ -65,6 +65,11 @@
         "comment": "Main iSCSI device",
         "template": "common/libvirt-templates/disk_template",
         "size": "191G"
+      },
+      "sdc": {
+        "comment": "NVMe-oF device",
+        "template": "common/libvirt-templates/disk_template",
+        "size": "20G"
       }
     }
   },

--- a/common/init-configs/1_hosted_engine_2_hosts.json
+++ b/common/init-configs/1_hosted_engine_2_hosts.json
@@ -46,6 +46,11 @@
         "comment": "Hosted engine storage",
         "template": "common/libvirt-templates/disk_template",
         "size": "80G"
+      },
+      "sdd": {
+        "comment": "NVMe-oF device",
+        "template": "common/libvirt-templates/disk_template",
+        "size": "20G"
       }
     }
   },

--- a/network-suite-master/ovirtlib/storagelib.py
+++ b/network-suite-master/ovirtlib/storagelib.py
@@ -28,6 +28,7 @@ class StorageType(object):
     ISCSI = types.StorageType.ISCSI
     LOCALFS = types.StorageType.LOCALFS
     NFS = types.StorageType.NFS
+    NVMEOF = types.StorageType.NVMEOF
     POSIXFS = types.StorageType.POSIXFS
 
 

--- a/ost_utils/constants.py
+++ b/ost_utils/constants.py
@@ -16,3 +16,4 @@ FLOATING_DISK_NAME = 'floating_disk'
 # Storage
 SD_NFS_NAME = 'nfs'
 SD_ISCSI_NAME = 'iscsi'
+SD_NVMEOF_NAME = 'nvmeof'

--- a/ost_utils/pytest/fixtures/env.py
+++ b/ost_utils/pytest/fixtures/env.py
@@ -42,6 +42,6 @@ def ost_images_distro():
 @pytest.fixture(scope='session')
 def master_storage_domain_type():
     sd_type = os.environ.get('OST_MASTER_SD_TYPE', 'nfs')
-    if sd_type not in ['nfs', 'iscsi']:
+    if sd_type not in ['nfs', 'iscsi', 'nvmeof']:
         raise RuntimeError(f'Unknown master_storage_domain_type {sd_type}')
     return sd_type

--- a/ost_utils/pytest/fixtures/storage.py
+++ b/ost_utils/pytest/fixtures/storage.py
@@ -33,15 +33,32 @@ def sd_nfs_host_storage_name():
 
 
 @pytest.fixture(scope="session")
+def sd_nvmeof_host_ip():
+    # return only one IP since we want to connect to just one endpoint
+    return 'Please override sd_nvmeof_host_ip'
+
+
+@pytest.fixture(scope="session")
+def sd_nvmeof_ansible_host():
+    return 'Please override sd_nvmeof_ansible_host'
+
+
+@pytest.fixture(scope="session")
 def sd_iscsi_ansible_host():
     return 'Please override sd_iscsi_ansible_host'
 
 
 @pytest.fixture(scope="session")
 def master_storage_domain_name(master_storage_domain_type):
-    return constants.SD_NFS_NAME if master_storage_domain_type == "nfs" else constants.SD_ISCSI_NAME
+    if master_storage_domain_type == "nfs":
+        return constants.SD_NFS_NAME
+    elif master_storage_domain_type == "nvmeof":
+        return constants.SD_NVMEOF_NAME
+    return constants.SD_ISCSI_NAME
 
 
 @pytest.fixture(scope="session")
 def secondary_storage_domain_name(master_storage_domain_type):
+    if master_storage_domain_type == "nvmeof":
+        return constants.SD_ISCSI_NAME
     return constants.SD_ISCSI_NAME if master_storage_domain_type == "nfs" else constants.SD_NFS_NAME

--- a/ost_utils/storage_utils/lun.py
+++ b/ost_utils/storage_utils/lun.py
@@ -34,3 +34,31 @@ def create_lun_sdk_entries(uuids, ip, port, target):
         luns.append(lun)
 
     return luns
+
+
+def get_nvmeof_uuids(ansible_vm):
+    encoded = ansible_vm.slurp(src='/root/nvmeof_uuids.txt')['content']
+    return [u.decode('utf-8') for u in base64.b64decode(encoded).splitlines()]
+
+
+def get_nvmeof_connection_info(ansible_vm):
+    encoded = ansible_vm.slurp(src='/root/nvmeof_connection.txt')['content']
+    parts = base64.b64decode(encoded).decode('utf-8').strip().split()
+    return {
+        'nqn': parts[0],
+        'address': parts[1],
+        'port': int(parts[2]),
+    }
+
+
+def create_nvmeof_lun_sdk_entries(uuids, address, port, nqn):
+    luns = []
+    for uuid in uuids:
+        lun = types.LogicalUnit(
+            id=uuid,
+            address=address,
+            port=port,
+            target=nqn,
+        )
+        luns.append(lun)
+    return luns


### PR DESCRIPTION
Add NVMe-oF/TCP storage domain support to oVirt. This is a block/shared storage domain type, analogous to iSCSI, using the built-in Linux NVMe 
initiator (nvme-cli). It supports both authenticated (DH-HMAC-CHAP) and non-authenticated NVMe-oF targets.

The feature try to be backend-agnostic for any NVMe/TCP target works (Ceph NVMe-oF Gateway is the reference implementation).

# Change :
- New storage domain type: nvmeof in REST API / Ansible / SDK
- Authentication : optional DH-HMAC-CHAP 
- Multipath : native NVMe multipath detected automatically; falls back to dm-mpath
- Host deployment: NVMe host NQN auto-detected from /etc/nvme/hostnqn

# Limitations :
- No iSCSI bond support for NVMe-oF
- NVMe-oF storage domain cannot be edited or imported via webadmin
